### PR TITLE
feat(frontend): dynamic + automatic form fields (#51)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -167,9 +167,8 @@ describe("Transactions form dynamic fields (issue #51)", () => {
     await user.click(screen.getByRole("button", { name: "transactions" }));
     const tipoSelect = await screen.findByLabelText("Tipo");
     expect(tipoSelect.tagName).toBe("SELECT");
-    expect(screen.getByRole("option", { name: "nuovo vincolo" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "cedola" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "Variazione Valore" })).toBeInTheDocument();
+    const optionNames = Array.from(tipoSelect.querySelectorAll("option")).map((o) => o.textContent);
+    expect(optionNames).toEqual(["nuovo vincolo", "cedola", "interessi", "cashback", "Variazione Valore"]);
   });
 
   test("default tipo 'nuovo vincolo' shows Buy value, hides PnL", async () => {
@@ -193,6 +192,39 @@ describe("Transactions form dynamic fields (issue #51)", () => {
       expect(screen.queryByLabelText("Buy value")).toBeNull();
       expect(screen.getByLabelText("PnL")).toBeInTheDocument();
     });
+  });
+
+  test("asset combobox keyboard nav: ArrowDown + Enter selects an option", async () => {
+    testState.transactions = [
+      { id: "tx-1", txDate: "2026-05-16", asset: "ETF-A", tipo: "nuovo vincolo", derivedType: "buy", buyValue: 1000, pnl: 0, currentValue: 1000, note: "" },
+      { id: "tx-2", txDate: "2026-05-17", asset: "ETF-B", tipo: "cedola", derivedType: "return", buyValue: 0, pnl: 25, currentValue: 25, note: "" }
+    ];
+    const user = userEvent.setup();
+    renderApp();
+    await screen.findByRole("heading", { name: "Dashboard" });
+    await user.click(screen.getByRole("button", { name: "transactions" }));
+    const assetInput = (await screen.findByLabelText("Asset")) as HTMLInputElement;
+    assetInput.focus();
+    await waitFor(() => expect(screen.getByRole("option", { name: "ETF-A" })).toBeInTheDocument());
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{Enter}");
+    expect(assetInput.value).toBe("ETF-B");
+  });
+
+  test("asset combobox Escape closes the list", async () => {
+    testState.transactions = [
+      { id: "tx-1", txDate: "2026-05-16", asset: "ETF-A", tipo: "nuovo vincolo", derivedType: "buy", buyValue: 1000, pnl: 0, currentValue: 1000, note: "" }
+    ];
+    const user = userEvent.setup();
+    renderApp();
+    await screen.findByRole("heading", { name: "Dashboard" });
+    await user.click(screen.getByRole("button", { name: "transactions" }));
+    const assetInput = (await screen.findByLabelText("Asset")) as HTMLInputElement;
+    assetInput.focus();
+    await waitFor(() => expect(screen.queryByRole("listbox")).toBeInTheDocument());
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(screen.queryByRole("listbox")).toBeNull());
   });
 
   test("asset combobox shows existing assets and selects on click", async () => {
@@ -244,27 +276,30 @@ describe("Snapshot auto-derive (issue #51)", () => {
     };
     let captured: unknown = null;
     const origFetch = globalThis.fetch;
-    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-      if (url.endsWith("/api/v1/monthly-snapshots") && init?.method === "POST") {
-        captured = JSON.parse(String(init.body));
-      }
-      return origFetch(input as RequestInfo, init);
-    };
-    const user = userEvent.setup();
-    renderApp();
-    await screen.findByRole("heading", { name: "Dashboard" });
-    await user.click(screen.getByRole("button", { name: "snapshots" }));
-    await screen.findByRole("heading", { name: "Monthly snapshots" });
-    await user.click(screen.getByRole("button", { name: "Add" }));
-    await waitFor(() => {
-      expect(captured).not.toBeNull();
-    });
-    globalThis.fetch = origFetch;
-    const body = captured as { lowRisk: number; mediumRisk: number; highRisk: number };
-    expect(body.lowRisk).toBe(0);
-    expect(body.mediumRisk).toBe(1050);
-    expect(body.highRisk).toBe(25);
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        if (url.endsWith("/api/v1/monthly-snapshots") && init?.method === "POST") {
+          captured = JSON.parse(String(init.body));
+        }
+        return origFetch(input as RequestInfo, init);
+      };
+      const user = userEvent.setup();
+      renderApp();
+      await screen.findByRole("heading", { name: "Dashboard" });
+      await user.click(screen.getByRole("button", { name: "snapshots" }));
+      await screen.findByRole("heading", { name: "Monthly snapshots" });
+      await user.click(screen.getByRole("button", { name: "Add" }));
+      await waitFor(() => {
+        expect(captured).not.toBeNull();
+      });
+      const body = captured as { lowRisk: number; mediumRisk: number; highRisk: number };
+      expect(body.lowRisk).toBe(0);
+      expect(body.mediumRisk).toBe(1050);
+      expect(body.highRisk).toBe(25);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
   });
 });
 
@@ -286,25 +321,28 @@ describe("Empty number inputs (placeholder, no inserted 0)", () => {
   test("submitting tx with empty Buy value sends 0 to backend (zod coerce)", async () => {
     let captured: { buyValue?: number } | null = null;
     const origFetch = globalThis.fetch;
-    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-      if (url.endsWith("/api/v1/transactions") && init?.method === "POST") {
-        captured = JSON.parse(String(init.body));
-      }
-      return origFetch(input as RequestInfo, init);
-    };
-    const user = userEvent.setup();
-    renderApp();
-    await screen.findByRole("heading", { name: "Dashboard" });
-    await user.click(screen.getByRole("button", { name: "transactions" }));
-    await screen.findByLabelText("Buy value");
-    await user.type(screen.getByLabelText("Asset"), "TEST");
-    await user.click(screen.getByRole("button", { name: "Add" }));
-    await waitFor(() => {
-      expect(captured).not.toBeNull();
-    });
-    globalThis.fetch = origFetch;
-    expect((captured as unknown as { buyValue: number }).buyValue).toBe(0);
+    try {
+      globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        if (url.endsWith("/api/v1/transactions") && init?.method === "POST") {
+          captured = JSON.parse(String(init.body));
+        }
+        return origFetch(input as RequestInfo, init);
+      };
+      const user = userEvent.setup();
+      renderApp();
+      await screen.findByRole("heading", { name: "Dashboard" });
+      await user.click(screen.getByRole("button", { name: "transactions" }));
+      await screen.findByLabelText("Buy value");
+      await user.type(screen.getByLabelText("Asset"), "TEST");
+      await user.click(screen.getByRole("button", { name: "Add" }));
+      await waitFor(() => {
+        expect(captured).not.toBeNull();
+      });
+      expect((captured as unknown as { buyValue: number }).buyValue).toBe(0);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
   });
 
   test("mm Amount and snapshot Liquid are empty with placeholder '0'", async () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -155,6 +155,194 @@ describe("Dashboard panel (authenticated state)", () => {
   });
 });
 
+describe("Transactions form dynamic fields (issue #51)", () => {
+  beforeEach(() => {
+    testState.authenticated = true;
+  });
+
+  test("tipo is a select with known options", async () => {
+    const user = userEvent.setup();
+    renderApp();
+    await screen.findByRole("heading", { name: "Dashboard" });
+    await user.click(screen.getByRole("button", { name: "transactions" }));
+    const tipoSelect = await screen.findByLabelText("Tipo");
+    expect(tipoSelect.tagName).toBe("SELECT");
+    expect(screen.getByRole("option", { name: "nuovo vincolo" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "cedola" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Variazione Valore" })).toBeInTheDocument();
+  });
+
+  test("default tipo 'nuovo vincolo' shows Buy value, hides PnL", async () => {
+    const user = userEvent.setup();
+    renderApp();
+    await screen.findByRole("heading", { name: "Dashboard" });
+    await user.click(screen.getByRole("button", { name: "transactions" }));
+    await screen.findByLabelText("Tipo");
+    expect(screen.getByLabelText("Buy value")).toBeInTheDocument();
+    expect(screen.queryByLabelText("PnL")).toBeNull();
+  });
+
+  test("switching to 'cedola' hides Buy value, shows PnL", async () => {
+    const user = userEvent.setup();
+    renderApp();
+    await screen.findByRole("heading", { name: "Dashboard" });
+    await user.click(screen.getByRole("button", { name: "transactions" }));
+    const tipo = await screen.findByLabelText("Tipo");
+    await user.selectOptions(tipo, "cedola");
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Buy value")).toBeNull();
+      expect(screen.getByLabelText("PnL")).toBeInTheDocument();
+    });
+  });
+
+  test("asset combobox shows existing assets and selects on click", async () => {
+    testState.transactions = [
+      { id: "tx-1", txDate: "2026-05-16", asset: "ETF-A", tipo: "nuovo vincolo", derivedType: "buy", buyValue: 1000, pnl: 0, currentValue: 1000, note: "" },
+      { id: "tx-2", txDate: "2026-05-17", asset: "ETF-B", tipo: "cedola", derivedType: "return", buyValue: 0, pnl: 25, currentValue: 25, note: "" }
+    ];
+    const user = userEvent.setup();
+    renderApp();
+    await screen.findByRole("heading", { name: "Dashboard" });
+    await user.click(screen.getByRole("button", { name: "transactions" }));
+    const assetInput = await screen.findByLabelText("Asset");
+    await user.click(assetInput);
+    const optionA = await screen.findByRole("option", { name: "ETF-A" });
+    expect(optionA).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "ETF-B" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "ETF-A" }));
+    expect((assetInput as HTMLInputElement).value).toBe("ETF-A");
+  });
+});
+
+describe("Snapshot auto-derive (issue #51)", () => {
+  beforeEach(() => {
+    testState.authenticated = true;
+  });
+
+  test("risk fields are hidden in the form (auto-computed at submit)", async () => {
+    const user = userEvent.setup();
+    renderApp();
+    await screen.findByRole("heading", { name: "Dashboard" });
+    await user.click(screen.getByRole("button", { name: "snapshots" }));
+    await screen.findByRole("heading", { name: "Monthly snapshots" });
+    expect(screen.queryByLabelText("Low risk")).toBeNull();
+    expect(screen.queryByLabelText("Medium risk")).toBeNull();
+    expect(screen.queryByLabelText("High risk")).toBeNull();
+    expect(screen.queryByRole("button", { name: /calcola da portafoglio/i })).toBeNull();
+    expect(screen.getByLabelText("Date")).toBeInTheDocument();
+    expect(screen.getByLabelText("Liquid")).toBeInTheDocument();
+  });
+
+  test("submit derives risk totals from current transactions + styles", async () => {
+    testState.transactions = [
+      { id: "tx-1", txDate: "2026-05-16", asset: "ETF-A", tipo: "nuovo vincolo", derivedType: "buy", buyValue: 1000, pnl: 50, currentValue: 1050, note: "" },
+      { id: "tx-2", txDate: "2026-05-17", asset: "ETF-B", tipo: "cedola", derivedType: "return", buyValue: 0, pnl: 25, currentValue: 25, note: "" }
+    ];
+    testState.styles = {
+      "ETF-A": { colorHex: null, riskLevel: "medium" },
+      "ETF-B": { colorHex: null, riskLevel: "high" }
+    };
+    let captured: unknown = null;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.endsWith("/api/v1/monthly-snapshots") && init?.method === "POST") {
+        captured = JSON.parse(String(init.body));
+      }
+      return origFetch(input as RequestInfo, init);
+    };
+    const user = userEvent.setup();
+    renderApp();
+    await screen.findByRole("heading", { name: "Dashboard" });
+    await user.click(screen.getByRole("button", { name: "snapshots" }));
+    await screen.findByRole("heading", { name: "Monthly snapshots" });
+    await user.click(screen.getByRole("button", { name: "Add" }));
+    await waitFor(() => {
+      expect(captured).not.toBeNull();
+    });
+    globalThis.fetch = origFetch;
+    const body = captured as { lowRisk: number; mediumRisk: number; highRisk: number };
+    expect(body.lowRisk).toBe(0);
+    expect(body.mediumRisk).toBe(1050);
+    expect(body.highRisk).toBe(25);
+  });
+});
+
+describe("Empty number inputs (placeholder, no inserted 0)", () => {
+  beforeEach(() => {
+    testState.authenticated = true;
+  });
+
+  test("tx Buy value is empty with placeholder '0'", async () => {
+    const user = userEvent.setup();
+    renderApp();
+    await screen.findByRole("heading", { name: "Dashboard" });
+    await user.click(screen.getByRole("button", { name: "transactions" }));
+    const buy = (await screen.findByLabelText("Buy value")) as HTMLInputElement;
+    expect(buy.value).toBe("");
+    expect(buy.placeholder).toBe("0");
+  });
+
+  test("submitting tx with empty Buy value sends 0 to backend (zod coerce)", async () => {
+    let captured: { buyValue?: number } | null = null;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.endsWith("/api/v1/transactions") && init?.method === "POST") {
+        captured = JSON.parse(String(init.body));
+      }
+      return origFetch(input as RequestInfo, init);
+    };
+    const user = userEvent.setup();
+    renderApp();
+    await screen.findByRole("heading", { name: "Dashboard" });
+    await user.click(screen.getByRole("button", { name: "transactions" }));
+    await screen.findByLabelText("Buy value");
+    await user.type(screen.getByLabelText("Asset"), "TEST");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+    await waitFor(() => {
+      expect(captured).not.toBeNull();
+    });
+    globalThis.fetch = origFetch;
+    expect((captured as unknown as { buyValue: number }).buyValue).toBe(0);
+  });
+
+  test("mm Amount and snapshot Liquid are empty with placeholder '0'", async () => {
+    const user = userEvent.setup();
+    renderApp();
+    await screen.findByRole("heading", { name: "Dashboard" });
+    await user.click(screen.getByRole("button", { name: "movements" }));
+    const amount = (await screen.findByLabelText("Amount")) as HTMLInputElement;
+    expect(amount.value).toBe("");
+    expect(amount.placeholder).toBe("0");
+    await user.click(screen.getByRole("button", { name: "snapshots" }));
+    const liquid = (await screen.findByLabelText("Liquid")) as HTMLInputElement;
+    expect(liquid.value).toBe("");
+    expect(liquid.placeholder).toBe("0");
+  });
+});
+
+describe("Snapshot table is add/delete-only (no edit)", () => {
+  beforeEach(() => {
+    testState.authenticated = true;
+    testState.snapshots = [
+      { id: "snap-1", snapshotDate: "2026-05-01", lowRisk: 100, mediumRisk: 200, highRisk: 50, liquid: 30 }
+    ];
+  });
+
+  test("snapshot row has Delete but no Edit", async () => {
+    const user = userEvent.setup();
+    renderApp();
+    await screen.findByRole("heading", { name: "Dashboard" });
+    await user.click(screen.getByRole("button", { name: "snapshots" }));
+    await screen.findByRole("heading", { name: "Monthly snapshots" });
+    const rowActions = document.querySelectorAll("table tbody tr td:last-child button");
+    const labels = Array.from(rowActions).map((b) => b.textContent);
+    expect(labels).toContain("Delete");
+    expect(labels).not.toContain("Edit");
+  });
+});
+
 describe("Logout flow", () => {
   test("logout button transitions back to login screen", async () => {
     const user = userEvent.setup();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -7,6 +7,19 @@ import { create } from "zustand";
 import { apiEnvelopeSchema, apiFetch, formatCurrency } from "./lib";
 import { mmSchema, snapSchema, txSchema } from "./types";
 import { DashboardPanel } from "./components/dashboard/DashboardPanel";
+import { computePerAsset } from "./lib/dashboard";
+
+const TIPO_OPTIONS = ["nuovo vincolo", "cedola", "interessi", "cashback", "Variazione Valore"] as const;
+const TIPO_PNL_ONLY = new Set<string>(["cedola", "interessi", "cashback", "Variazione Valore"]);
+const TIPO_BUY_ONLY = new Set<string>(["nuovo vincolo"]);
+function tipoShowsBuyValue(tipo: string): boolean {
+  if (TIPO_PNL_ONLY.has(tipo)) return false;
+  return true;
+}
+function tipoShowsPnl(tipo: string): boolean {
+  if (TIPO_BUY_ONLY.has(tipo)) return false;
+  return true;
+}
 
 type User = { id: number; email: string; name: string | null };
 type AuthState = { user: User | null; setUser: (user: User | null) => void };
@@ -50,9 +63,6 @@ const mmFormSchema = z.object({
 
 const snapFormSchema = z.object({
   snapshotDate: z.string().min(1),
-  lowRisk: z.coerce.number(),
-  mediumRisk: z.coerce.number(),
-  highRisk: z.coerce.number(),
   liquid: z.coerce.number()
 });
 
@@ -65,7 +75,6 @@ function App() {
   const [nav, setNav] = useState<NavItem>("dashboard");
   const [editingTxId, setEditingTxId] = useState<string | null>(null);
   const [editingMmId, setEditingMmId] = useState<string | null>(null);
-  const [editingSnapId, setEditingSnapId] = useState<string | null>(null);
   const [styleJson, setStyleJson] = useState("{}");
 
   const sessionQuery = useQuery({
@@ -129,19 +138,49 @@ function App() {
       txDate: new Date().toISOString().slice(0, 10),
       asset: "",
       tipo: "nuovo vincolo",
-      buyValue: 0,
-      pnl: 0,
+      // reason: empty string renders placeholder; z.coerce.number maps "" → 0 at submit
+      buyValue: "" as unknown as number,
+      pnl: "" as unknown as number,
       note: ""
     }
   });
-  const mmForm = useForm<z.infer<typeof mmFormSchema>>({ defaultValues: { name: "", direction: "income", amount: 0, note: "" } });
+  const watchedTipo = txForm.watch("tipo");
+  const showBuyValue = tipoShowsBuyValue(watchedTipo);
+  const showPnl = tipoShowsPnl(watchedTipo);
+  useEffect(() => {
+    if (!showBuyValue) txForm.setValue("buyValue", 0);
+    if (!showPnl) txForm.setValue("pnl", 0);
+  }, [showBuyValue, showPnl, txForm]);
+
+  const assetOptions = useMemo(() => {
+    const set = new Set<string>();
+    for (const row of txQuery.data ?? []) {
+      if (row.asset) set.add(row.asset);
+    }
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [txQuery.data]);
+
+  const [assetComboOpen, setAssetComboOpen] = useState(false);
+  const watchedAsset = txForm.watch("asset");
+  const filteredAssetOptions = useMemo(() => {
+    const q = (watchedAsset ?? "").toLowerCase().trim();
+    if (!q) return assetOptions;
+    return assetOptions.filter((a) => a.toLowerCase().includes(q) && a.toLowerCase() !== q);
+  }, [assetOptions, watchedAsset]);
+  const mmForm = useForm<z.infer<typeof mmFormSchema>>({
+    defaultValues: {
+      name: "",
+      direction: "income",
+      // reason: empty string renders placeholder; z.coerce.number maps "" → 0 at submit
+      amount: "" as unknown as number,
+      note: ""
+    }
+  });
   const snapForm = useForm<z.infer<typeof snapFormSchema>>({
     defaultValues: {
       snapshotDate: new Date().toISOString().slice(0, 10),
-      lowRisk: 0,
-      mediumRisk: 0,
-      highRisk: 0,
-      liquid: 0
+      // reason: empty string renders placeholder; z.coerce.number maps "" → 0 at submit
+      liquid: "" as unknown as number
     }
   });
 
@@ -212,7 +251,7 @@ function App() {
     },
     onSuccess: async () => {
       setEditingTxId(null);
-      txForm.reset({ txDate: new Date().toISOString().slice(0, 10), asset: "", tipo: "nuovo vincolo", buyValue: 0, pnl: 0, note: "" });
+      txForm.reset({ txDate: new Date().toISOString().slice(0, 10), asset: "", tipo: "nuovo vincolo", buyValue: "" as unknown as number, pnl: "" as unknown as number, note: "" });
       await queryClient.invalidateQueries({ queryKey: ["transactions"] });
     }
   });
@@ -235,21 +274,29 @@ function App() {
     },
     onSuccess: async () => {
       setEditingMmId(null);
-      mmForm.reset({ name: "", direction: "income", amount: 0, note: "" });
+      mmForm.reset({ name: "", direction: "income", amount: "" as unknown as number, note: "" });
       await queryClient.invalidateQueries({ queryKey: ["movements"] });
     }
   });
 
   const snapMutation = useMutation({
     mutationFn: async (values: z.infer<typeof snapFormSchema>) => {
-      const payload = snapFormSchema.parse(values);
-      if (editingSnapId) {
-        return apiFetch(
-          `/api/v1/monthly-snapshots/${editingSnapId}`,
-          { method: "PUT", body: JSON.stringify(payload) },
-          (raw) => apiEnvelopeSchema(z.object({ ok: z.boolean() })).parse(raw).data
-        );
+      const form = snapFormSchema.parse(values);
+      const stats = computePerAsset(txQuery.data ?? [], stylesQuery.data);
+      const totals = { low: 0, medium: 0, high: 0 };
+      for (const s of stats) {
+        if (s.riskLevel === "low") totals.low += s.current;
+        else if (s.riskLevel === "medium") totals.medium += s.current;
+        else if (s.riskLevel === "high") totals.high += s.current;
       }
+      const round2 = (n: number) => Math.round(n * 100) / 100;
+      const payload = {
+        snapshotDate: form.snapshotDate,
+        lowRisk: round2(totals.low),
+        mediumRisk: round2(totals.medium),
+        highRisk: round2(totals.high),
+        liquid: form.liquid
+      };
       return apiFetch(
         "/api/v1/monthly-snapshots",
         { method: "POST", body: JSON.stringify(payload) },
@@ -257,8 +304,7 @@ function App() {
       );
     },
     onSuccess: async () => {
-      setEditingSnapId(null);
-      snapForm.reset({ snapshotDate: new Date().toISOString().slice(0, 10), lowRisk: 0, mediumRisk: 0, highRisk: 0, liquid: 0 });
+      snapForm.reset({ snapshotDate: new Date().toISOString().slice(0, 10), liquid: "" as unknown as number });
       await queryClient.invalidateQueries({ queryKey: ["snapshots"] });
     }
   });
@@ -394,16 +440,55 @@ function App() {
       {nav === "transactions" && (
         <section className="panel">
           <h2>Transactions</h2>
-          <form className="form-grid" onSubmit={txForm.handleSubmit((v) => txMutation.mutate(v))}>
-            <label>Date<input type="date" {...txForm.register("txDate")} /></label>
-            <label>Asset<input {...txForm.register("asset")} /></label>
-            <label>Tipo<input {...txForm.register("tipo")} /></label>
-            <label>Buy value<input type="number" step="0.01" {...txForm.register("buyValue", { valueAsNumber: true })} /></label>
-            <label>PnL<input type="number" step="0.01" {...txForm.register("pnl", { valueAsNumber: true })} /></label>
-            <label>Note<textarea {...txForm.register("note")} /></label>
+          <form onSubmit={txForm.handleSubmit((v) => txMutation.mutate(v))}>
+            <div className="form-grid">
+              <label>Date<input type="date" {...txForm.register("txDate")} /></label>
+              <label className="combo">
+                Asset
+                <input
+                  type="text"
+                  autoComplete="off"
+                  placeholder={assetOptions.length > 0 ? "digita o scegli" : "es. revolut"}
+                  role="combobox"
+                  aria-expanded={assetComboOpen}
+                  aria-controls="tx-asset-combo-list"
+                  {...txForm.register("asset")}
+                  onFocus={() => setAssetComboOpen(true)}
+                  onBlur={() => window.setTimeout(() => setAssetComboOpen(false), 120)}
+                />
+                {assetComboOpen && filteredAssetOptions.length > 0 && (
+                  <ul id="tx-asset-combo-list" className="combo-list" role="listbox">
+                    {filteredAssetOptions.slice(0, 8).map((a) => (
+                      <li key={a} role="option" aria-selected={watchedAsset === a}>
+                        <button
+                          type="button"
+                          className="combo-item"
+                          onMouseDown={(e) => {
+                            e.preventDefault();
+                            txForm.setValue("asset", a, { shouldDirty: true });
+                            setAssetComboOpen(false);
+                          }}
+                        >
+                          {a}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </label>
+              <label>
+                Tipo
+                <select {...txForm.register("tipo")}>
+                  {TIPO_OPTIONS.map((t) => <option key={t} value={t}>{t}</option>)}
+                </select>
+              </label>
+              {showBuyValue && <label>Buy value<input type="number" step="0.01" placeholder="0" {...txForm.register("buyValue")} /></label>}
+              {showPnl && <label>PnL<input type="number" step="0.01" placeholder="0" {...txForm.register("pnl")} /></label>}
+              <label>Note<textarea {...txForm.register("note")} /></label>
+            </div>
             <div className="row-actions">
               <button type="submit">{editingTxId ? "Update" : "Add"}</button>
-              {editingTxId && <button type="button" onClick={() => { setEditingTxId(null); txForm.reset({ txDate: new Date().toISOString().slice(0, 10), asset: "", tipo: "nuovo vincolo", buyValue: 0, pnl: 0, note: "" }); }}>Cancel</button>}
+              {editingTxId && <button type="button" onClick={() => { setEditingTxId(null); txForm.reset({ txDate: new Date().toISOString().slice(0, 10), asset: "", tipo: "nuovo vincolo", buyValue: "" as unknown as number, pnl: "" as unknown as number, note: "" }); }}>Cancel</button>}
             </div>
           </form>
 
@@ -431,12 +516,14 @@ function App() {
       {nav === "movements" && (
         <section className="panel">
           <h2>Monthly movements</h2>
-          <form className="form-grid" onSubmit={mmForm.handleSubmit((v) => mmMutation.mutate(v))}>
-            <label>Name<input {...mmForm.register("name")} /></label>
-            <label>Direction<select {...mmForm.register("direction")}><option value="income">income</option><option value="expense">expense</option></select></label>
-            <label>Amount<input type="number" step="0.01" {...mmForm.register("amount", { valueAsNumber: true })} /></label>
-            <label>Note<textarea {...mmForm.register("note")} /></label>
-            <div className="row-actions"><button type="submit">{editingMmId ? "Update" : "Add"}</button>{editingMmId && <button type="button" onClick={() => { setEditingMmId(null); mmForm.reset({ name: "", direction: "income", amount: 0, note: "" }); }}>Cancel</button>}</div>
+          <form onSubmit={mmForm.handleSubmit((v) => mmMutation.mutate(v))}>
+            <div className="form-grid">
+              <label>Name<input {...mmForm.register("name")} /></label>
+              <label>Direction<select {...mmForm.register("direction")}><option value="income">income</option><option value="expense">expense</option></select></label>
+              <label>Amount<input type="number" step="0.01" placeholder="0" {...mmForm.register("amount")} /></label>
+              <label>Note<textarea {...mmForm.register("note")} /></label>
+            </div>
+            <div className="row-actions"><button type="submit">{editingMmId ? "Update" : "Add"}</button>{editingMmId && <button type="button" onClick={() => { setEditingMmId(null); mmForm.reset({ name: "", direction: "income", amount: "" as unknown as number, note: "" }); }}>Cancel</button>}</div>
           </form>
 
           <table>
@@ -461,13 +548,14 @@ function App() {
       {nav === "snapshots" && (
         <section className="panel">
           <h2>Monthly snapshots</h2>
-          <form className="form-grid" onSubmit={snapForm.handleSubmit((v) => snapMutation.mutate(v))}>
-            <label>Date<input type="date" {...snapForm.register("snapshotDate")} /></label>
-            <label>Low risk<input type="number" step="0.01" {...snapForm.register("lowRisk", { valueAsNumber: true })} /></label>
-            <label>Medium risk<input type="number" step="0.01" {...snapForm.register("mediumRisk", { valueAsNumber: true })} /></label>
-            <label>High risk<input type="number" step="0.01" {...snapForm.register("highRisk", { valueAsNumber: true })} /></label>
-            <label>Liquid<input type="number" step="0.01" {...snapForm.register("liquid", { valueAsNumber: true })} /></label>
-            <div className="row-actions"><button type="submit">{editingSnapId ? "Update" : "Add"}</button>{editingSnapId && <button type="button" onClick={() => { setEditingSnapId(null); snapForm.reset({ snapshotDate: new Date().toISOString().slice(0, 10), lowRisk: 0, mediumRisk: 0, highRisk: 0, liquid: 0 }); }}>Cancel</button>}</div>
+          <form onSubmit={snapForm.handleSubmit((v) => snapMutation.mutate(v))}>
+            <div className="form-grid">
+              <label>Date<input type="date" {...snapForm.register("snapshotDate")} /></label>
+              <label>Liquid<input type="number" step="0.01" placeholder="0" {...snapForm.register("liquid")} /></label>
+            </div>
+            <div className="row-actions">
+              <button type="submit">Add</button>
+            </div>
           </form>
 
           <table>
@@ -481,7 +569,6 @@ function App() {
                   <td>{formatCurrency(row.highRisk)}</td>
                   <td>{formatCurrency(row.liquid)}</td>
                   <td>
-                    <button onClick={() => { setEditingSnapId(row.id); snapForm.reset({ snapshotDate: row.snapshotDate, lowRisk: row.lowRisk, mediumRisk: row.mediumRisk, highRisk: row.highRisk, liquid: row.liquid }); }}>Edit</button>
                     <button onClick={() => deleteMutation.mutate({ path: `/api/v1/monthly-snapshots/${row.id}` })}>Delete</button>
                   </td>
                 </tr>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -147,10 +147,6 @@ function App() {
   const watchedTipo = txForm.watch("tipo");
   const showBuyValue = tipoShowsBuyValue(watchedTipo);
   const showPnl = tipoShowsPnl(watchedTipo);
-  useEffect(() => {
-    if (!showBuyValue) txForm.setValue("buyValue", 0);
-    if (!showPnl) txForm.setValue("pnl", 0);
-  }, [showBuyValue, showPnl, txForm]);
 
   const assetOptions = useMemo(() => {
     const set = new Set<string>();
@@ -161,12 +157,47 @@ function App() {
   }, [txQuery.data]);
 
   const [assetComboOpen, setAssetComboOpen] = useState(false);
+  const [assetFocusedIdx, setAssetFocusedIdx] = useState(-1);
   const watchedAsset = txForm.watch("asset");
   const filteredAssetOptions = useMemo(() => {
     const q = (watchedAsset ?? "").toLowerCase().trim();
     if (!q) return assetOptions;
     return assetOptions.filter((a) => a.toLowerCase().includes(q) && a.toLowerCase() !== q);
   }, [assetOptions, watchedAsset]);
+
+  useEffect(() => {
+    setAssetFocusedIdx(-1);
+  }, [watchedAsset, assetComboOpen]);
+
+  const visibleAssetOptions = filteredAssetOptions.slice(0, 8);
+  const selectAssetOption = (a: string) => {
+    txForm.setValue("asset", a, { shouldDirty: true });
+    setAssetComboOpen(false);
+    setAssetFocusedIdx(-1);
+  };
+  const handleAssetKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (!assetComboOpen) setAssetComboOpen(true);
+      setAssetFocusedIdx((i) => (visibleAssetOptions.length === 0 ? -1 : (i + 1) % visibleAssetOptions.length));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (!assetComboOpen) setAssetComboOpen(true);
+      setAssetFocusedIdx((i) => {
+        if (visibleAssetOptions.length === 0) return -1;
+        return i <= 0 ? visibleAssetOptions.length - 1 : i - 1;
+      });
+    } else if (e.key === "Enter" && assetComboOpen && assetFocusedIdx >= 0) {
+      const choice = visibleAssetOptions[assetFocusedIdx];
+      if (choice) {
+        e.preventDefault();
+        selectAssetOption(choice);
+      }
+    } else if (e.key === "Escape" && assetComboOpen) {
+      e.preventDefault();
+      setAssetComboOpen(false);
+    }
+  };
   const mmForm = useForm<z.infer<typeof mmFormSchema>>({
     defaultValues: {
       name: "",
@@ -227,13 +258,15 @@ function App() {
   const txMutation = useMutation({
     mutationFn: async (values: z.infer<typeof txFormSchema>) => {
       const parsed = txFormSchema.parse(values);
+      const buyValue = tipoShowsBuyValue(parsed.tipo) ? Number(parsed.buyValue) : 0;
+      const pnl = tipoShowsPnl(parsed.tipo) ? Number(parsed.pnl) : 0;
       const payload = {
         txDate: parsed.txDate,
         asset: parsed.asset,
         tipo: parsed.tipo,
-        buyValue: Number(parsed.buyValue),
-        pnl: Number(parsed.pnl),
-        currentValue: Number(parsed.buyValue) + Number(parsed.pnl),
+        buyValue,
+        pnl,
+        currentValue: buyValue + pnl,
         note: parsed.note
       };
       if (editingTxId) {
@@ -282,7 +315,10 @@ function App() {
   const snapMutation = useMutation({
     mutationFn: async (values: z.infer<typeof snapFormSchema>) => {
       const form = snapFormSchema.parse(values);
-      const stats = computePerAsset(txQuery.data ?? [], stylesQuery.data);
+      if (!txQuery.isSuccess || !stylesQuery.isSuccess) {
+        throw new Error("Attendi il caricamento di transazioni e stili asset prima di creare uno snapshot.");
+      }
+      const stats = computePerAsset(txQuery.data, stylesQuery.data);
       const totals = { low: 0, medium: 0, high: 0 };
       for (const s of stats) {
         if (s.riskLevel === "low") totals.low += s.current;
@@ -442,31 +478,33 @@ function App() {
           <h2>Transactions</h2>
           <form onSubmit={txForm.handleSubmit((v) => txMutation.mutate(v))}>
             <div className="form-grid">
-              <label>Date<input type="date" {...txForm.register("txDate")} /></label>
-              <label className="combo">
+              <label htmlFor="tx-date">Date<input id="tx-date" type="date" {...txForm.register("txDate")} /></label>
+              <label htmlFor="tx-asset" className="combo">
                 Asset
                 <input
+                  id="tx-asset"
                   type="text"
                   autoComplete="off"
                   placeholder={assetOptions.length > 0 ? "digita o scegli" : "es. revolut"}
                   role="combobox"
                   aria-expanded={assetComboOpen}
                   aria-controls="tx-asset-combo-list"
+                  aria-activedescendant={assetComboOpen && assetFocusedIdx >= 0 ? `tx-asset-opt-${assetFocusedIdx}` : undefined}
                   {...txForm.register("asset")}
                   onFocus={() => setAssetComboOpen(true)}
                   onBlur={() => window.setTimeout(() => setAssetComboOpen(false), 120)}
+                  onKeyDown={handleAssetKeyDown}
                 />
-                {assetComboOpen && filteredAssetOptions.length > 0 && (
+                {assetComboOpen && visibleAssetOptions.length > 0 && (
                   <ul id="tx-asset-combo-list" className="combo-list" role="listbox">
-                    {filteredAssetOptions.slice(0, 8).map((a) => (
-                      <li key={a} role="option" aria-selected={watchedAsset === a}>
+                    {visibleAssetOptions.map((a, idx) => (
+                      <li key={a} id={`tx-asset-opt-${idx}`} role="option" aria-selected={assetFocusedIdx === idx}>
                         <button
                           type="button"
-                          className="combo-item"
+                          className={"combo-item" + (assetFocusedIdx === idx ? " is-focused" : "")}
                           onMouseDown={(e) => {
                             e.preventDefault();
-                            txForm.setValue("asset", a, { shouldDirty: true });
-                            setAssetComboOpen(false);
+                            selectAssetOption(a);
                           }}
                         >
                           {a}
@@ -476,15 +514,15 @@ function App() {
                   </ul>
                 )}
               </label>
-              <label>
+              <label htmlFor="tx-tipo">
                 Tipo
-                <select {...txForm.register("tipo")}>
+                <select id="tx-tipo" {...txForm.register("tipo")}>
                   {TIPO_OPTIONS.map((t) => <option key={t} value={t}>{t}</option>)}
                 </select>
               </label>
-              {showBuyValue && <label>Buy value<input type="number" step="0.01" placeholder="0" {...txForm.register("buyValue")} /></label>}
-              {showPnl && <label>PnL<input type="number" step="0.01" placeholder="0" {...txForm.register("pnl")} /></label>}
-              <label>Note<textarea {...txForm.register("note")} /></label>
+              {showBuyValue && <label htmlFor="tx-buyValue">Buy value<input id="tx-buyValue" type="number" step="0.01" placeholder="0" {...txForm.register("buyValue")} /></label>}
+              {showPnl && <label htmlFor="tx-pnl">PnL<input id="tx-pnl" type="number" step="0.01" placeholder="0" {...txForm.register("pnl")} /></label>}
+              <label htmlFor="tx-note">Note<textarea id="tx-note" {...txForm.register("note")} /></label>
             </div>
             <div className="row-actions">
               <button type="submit">{editingTxId ? "Update" : "Add"}</button>
@@ -518,10 +556,10 @@ function App() {
           <h2>Monthly movements</h2>
           <form onSubmit={mmForm.handleSubmit((v) => mmMutation.mutate(v))}>
             <div className="form-grid">
-              <label>Name<input {...mmForm.register("name")} /></label>
-              <label>Direction<select {...mmForm.register("direction")}><option value="income">income</option><option value="expense">expense</option></select></label>
-              <label>Amount<input type="number" step="0.01" placeholder="0" {...mmForm.register("amount")} /></label>
-              <label>Note<textarea {...mmForm.register("note")} /></label>
+              <label htmlFor="mm-name">Name<input id="mm-name" type="text" {...mmForm.register("name")} /></label>
+              <label htmlFor="mm-direction">Direction<select id="mm-direction" {...mmForm.register("direction")}><option value="income">income</option><option value="expense">expense</option></select></label>
+              <label htmlFor="mm-amount">Amount<input id="mm-amount" type="number" step="0.01" placeholder="0" {...mmForm.register("amount")} /></label>
+              <label htmlFor="mm-note">Note<textarea id="mm-note" {...mmForm.register("note")} /></label>
             </div>
             <div className="row-actions"><button type="submit">{editingMmId ? "Update" : "Add"}</button>{editingMmId && <button type="button" onClick={() => { setEditingMmId(null); mmForm.reset({ name: "", direction: "income", amount: "" as unknown as number, note: "" }); }}>Cancel</button>}</div>
           </form>
@@ -550,11 +588,11 @@ function App() {
           <h2>Monthly snapshots</h2>
           <form onSubmit={snapForm.handleSubmit((v) => snapMutation.mutate(v))}>
             <div className="form-grid">
-              <label>Date<input type="date" {...snapForm.register("snapshotDate")} /></label>
-              <label>Liquid<input type="number" step="0.01" placeholder="0" {...snapForm.register("liquid")} /></label>
+              <label htmlFor="snap-date">Date<input id="snap-date" type="date" {...snapForm.register("snapshotDate")} /></label>
+              <label htmlFor="snap-liquid">Liquid<input id="snap-liquid" type="number" step="0.01" placeholder="0" {...snapForm.register("liquid")} /></label>
             </div>
             <div className="row-actions">
-              <button type="submit">Add</button>
+              <button type="submit" disabled={!txQuery.isSuccess || !stylesQuery.isSuccess}>Add</button>
             </div>
           </form>
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -106,6 +106,37 @@ input, select, textarea {
 
 textarea { min-height: 78px; }
 
+.combo { position: relative; }
+.combo-list {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin: 4px 0 0;
+  padding: 4px;
+  list-style: none;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  z-index: 20;
+  max-height: 220px;
+  overflow-y: auto;
+  box-shadow: 0 10px 24px rgba(0,0,0,0.4);
+}
+.combo-list li { margin: 0; }
+.combo-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 8px 10px;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--text);
+  cursor: pointer;
+}
+.combo-item:hover, .combo-item:focus { background: rgba(255,255,255,0.06); }
+
 .row-actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
 
 .stats-grid {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -135,7 +135,7 @@ textarea { min-height: 78px; }
   color: var(--text);
   cursor: pointer;
 }
-.combo-item:hover, .combo-item:focus { background: rgba(255,255,255,0.06); }
+.combo-item:hover, .combo-item:focus, .combo-item.is-focused { background: rgba(255,255,255,0.06); }
 
 .row-actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
 

--- a/tests/transaction-journey.spec.ts
+++ b/tests/transaction-journey.spec.ts
@@ -14,9 +14,8 @@ test.describe("transaction journey", () => {
 
     await page.getByLabel("Date").fill("2026-05-16");
     await page.getByLabel("Asset").fill("ETF-A");
-    await page.getByLabel("Tipo").fill("nuovo vincolo");
+    await page.getByLabel("Tipo").selectOption("nuovo vincolo");
     await page.getByLabel("Buy value").fill("1000");
-    await page.getByLabel("PnL").fill("50");
     await page.getByRole("button", { name: "Add" }).click();
 
     await expect(page.getByRole("cell", { name: "ETF-A" })).toBeVisible();
@@ -32,9 +31,8 @@ test.describe("transaction journey", () => {
     await page.getByRole("button", { name: "transactions" }).click();
     await page.getByLabel("Date").fill("2026-05-16");
     await page.getByLabel("Asset").fill("ETF-DEL");
-    await page.getByLabel("Tipo").fill("nuovo vincolo");
+    await page.getByLabel("Tipo").selectOption("nuovo vincolo");
     await page.getByLabel("Buy value").fill("500");
-    await page.getByLabel("PnL").fill("0");
     await page.getByRole("button", { name: "Add" }).click();
     await expect(page.getByRole("cell", { name: "ETF-DEL" })).toBeVisible();
 


### PR DESCRIPTION
## Summary

Make transaction, movement and snapshot form fields adapt to context
and infer values the app already has, instead of asking the user.

Closes #51

## What changed

### Transactions
- `tipo` is now a `<select>` with known options (`nuovo vincolo`,
  `cedola`, `interessi`, `cashback`, `Variazione Valore`).
- `Buy value` and `PnL` render conditionally based on `tipo`:
  - `nuovo vincolo` → only Buy value
  - `cedola` / `interessi` / `cashback` / `Variazione Valore` → only PnL
- Hidden numeric fields are zeroed at submit so the backend contract
  is preserved.
- `Asset` is now a custom combobox (input + suggestion list from
  existing transactions). Native `<datalist>` was dropped because
  Chrome's UX (chevron + floating tooltip) felt broken. Placeholder
  is dynamic: `digita o scegli` when there are options, else
  `es. revolut`.

### Snapshots
- `lowRisk` / `mediumRisk` / `highRisk` inputs removed. Totals are
  derived at submit from `computePerAsset(transactions, styles)` and
  injected into the payload — the same logic used by the dashboard.
- Snapshot rows are now **add/delete-only**. Editing a point-in-time
  aggregate doesn't make sense once the underlying portfolio changes.

### Number inputs (Buy value, PnL, Amount, Liquid)
- Render empty with `placeholder="0"` instead of a literal `0`.
- `z.coerce.number()` maps empty string to `0` at parse time, so the
  DB still receives a valid number.

### Layout
- `row-actions` (submit button) moved **out** of `.form-grid`. With
  the button as a grid cell it competed visually with the tall Note
  textarea at wide viewports. Now it sits on its own row.
- Added `.combo` / `.combo-list` / `.combo-item` styles using existing
  design tokens (`--panel`, `--border`, `--text`).

## Tests

`npm test` → 44/44 vitest cases (10 new):

- tipo select offers known options
- default tipo `nuovo vincolo` shows Buy value, hides PnL
- switching to `cedola` hides Buy value, shows PnL
- asset combobox shows existing assets and selects on click
- snapshot form has no risk inputs or "Calcola da portafoglio" button
- submit derives risk totals from current transactions + styles
- tx Buy value empty + placeholder `0`
- submitting empty Buy value sends `0` to backend (zod coerce)
- mm Amount and snap Liquid empty + placeholder `0`
- snapshot row has Delete but no Edit

## Test plan

- [x] `npm run build` (tsc + vite) green
- [x] `npm test` 44/44 pass
- [x] Manual smoke at 2000px viewport: form one-row layout, no overlap,
      combobox opens on focus and selects on click, Add button isolated
      below the grid
- [ ] Verify on production-built bundle after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>