### PR TITLE
ci: rename master to main in workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 permissions:

--- a/.github/workflows/dependabot-lockfile-sync.yml
+++ b/.github/workflows/dependabot-lockfile-sync.yml
@@ -2,7 +2,7 @@ name: Dependabot lockfile sync
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Updates \`ci.yml\` and \`dependabot-lockfile-sync.yml\` to reference \`main\` instead of \`master\` in their \`branches:\` filters.

## Why

Preparing to rename the default branch from \`master\` to \`main\`. GitHub keeps an HTTP-level redirect for the old name, but workflow \`branches:\` filters are matched against the literal ref string — no redirect. Without this commit landing first, both workflows would stop firing on the renamed branch.

## Sequence

1. Merge this PR (still on \`master\`).
2. Rename \`master\` → \`main\` via \`gh api -X POST repos/LiukScot/money/branches/master/rename -f new_name=main\`.
3. Local clones: \`git branch -m master main && git fetch origin && git branch -u origin/main main && git remote set-head origin -a\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)