### PR TITLE
feat(frontend): downshift-based AssetCombobox (#57 medium)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "chart.js": "^4.5.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "downshift": "^9.3.3",
         "lucide-react": "^1.16.0",
         "radix-ui": "^1.4.3",
         "react": "^19.2.0",
@@ -501,7 +502,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -4521,6 +4521,12 @@
         "node": ">=20"
       }
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
+    },
     "node_modules/content-disposition": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
@@ -4871,6 +4877,28 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/downshift": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.3.3.tgz",
+      "integrity": "sha512-otjI/WtoFcIXwPOyIQYkbrAZJA2Gjz67F8ENOh1RvmJalOg6fk0KEx4ljJSFuJB54ryc6doymPkCM+GjAZ7zjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "compute-scroll-into-view": "^3.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.12.0"
+      }
+    },
+    "node_modules/downshift/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6425,7 +6453,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -6720,6 +6747,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -7149,7 +7188,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7640,6 +7678,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "chart.js": "^4.5.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "downshift": "^9.3.3",
     "lucide-react": "^1.16.0",
     "radix-ui": "^1.4.3",
     "react": "^19.2.0",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -208,7 +208,7 @@ describe("Transactions form dynamic fields (issue #51)", () => {
     renderApp();
     await screen.findByRole("heading", { name: "Dashboard" });
     await user.click(screen.getByRole("link", { name: "transactions" }));
-    const assetInput = (await screen.findByLabelText("Asset")) as HTMLInputElement;
+    const assetInput = (await screen.findByRole("combobox", { name: "Asset" })) as HTMLInputElement;
     assetInput.focus();
     await waitFor(() => expect(screen.getByRole("option", { name: "ETF-A" })).toBeInTheDocument());
     await user.keyboard("{ArrowDown}");
@@ -225,7 +225,7 @@ describe("Transactions form dynamic fields (issue #51)", () => {
     renderApp();
     await screen.findByRole("heading", { name: "Dashboard" });
     await user.click(screen.getByRole("link", { name: "transactions" }));
-    const assetInput = (await screen.findByLabelText("Asset")) as HTMLInputElement;
+    const assetInput = (await screen.findByRole("combobox", { name: "Asset" })) as HTMLInputElement;
     assetInput.focus();
     await waitFor(() => expect(screen.queryByRole("listbox")).toBeInTheDocument());
     await user.keyboard("{Escape}");
@@ -241,12 +241,12 @@ describe("Transactions form dynamic fields (issue #51)", () => {
     renderApp();
     await screen.findByRole("heading", { name: "Dashboard" });
     await user.click(screen.getByRole("link", { name: "transactions" }));
-    const assetInput = await screen.findByLabelText("Asset");
+    const assetInput = await screen.findByRole("combobox", { name: "Asset" });
     await user.click(assetInput);
     const optionA = await screen.findByRole("option", { name: "ETF-A" });
     expect(optionA).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "ETF-B" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "ETF-A" }));
+    await user.click(screen.getByRole("option", { name: "ETF-A" }));
     expect((assetInput as HTMLInputElement).value).toBe("ETF-A");
   });
 });
@@ -339,7 +339,7 @@ describe("Empty number inputs (placeholder, no inserted 0)", () => {
       await screen.findByRole("heading", { name: "Dashboard" });
       await user.click(screen.getByRole("link", { name: "transactions" }));
       await screen.findByLabelText("Buy value");
-      await user.type(screen.getByLabelText("Asset"), "TEST");
+      await user.type(screen.getByRole("combobox", { name: "Asset" }), "TEST");
       await user.click(screen.getByRole("button", { name: "Add" }));
       await waitFor(() => {
         expect(captured).not.toBeNull();

--- a/frontend/src/features/transactions/AssetCombobox.tsx
+++ b/frontend/src/features/transactions/AssetCombobox.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import { useMemo } from "react";
+import { useCombobox } from "downshift";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
@@ -13,13 +14,7 @@ type Props = {
 };
 
 const MAX_VISIBLE = 8;
-const BLUR_CLOSE_DELAY_MS = 120;
 
-/**
- * Accessible asset autocomplete. Owns its own open/focus state but is
- * controlled by `value`/`onChange` so it can be wired to react-hook-form
- * via Controller.
- */
 export function AssetCombobox({
   id,
   label,
@@ -29,133 +24,85 @@ export function AssetCombobox({
   emptyPlaceholder = "es. revolut",
   populatedPlaceholder = "digita o scegli"
 }: Props) {
-  const [open, setOpen] = useState(false);
-  const [focusedIdx, setFocusedIdx] = useState(-1);
-  // Track the pending blur-close timeout so we can clear it on unmount or
-  // when the component refocuses (AGENTS.md §13: every setTimeout needs a
-  // cleanup path).
-  const blurTimeoutRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (blurTimeoutRef.current !== null) {
-        window.clearTimeout(blurTimeoutRef.current);
-      }
-    };
-  }, []);
-
   const filtered = useMemo(() => {
     const q = (value ?? "").toLowerCase().trim();
-    if (!q) return options;
-    return options.filter((a) => a.toLowerCase().includes(q) && a.toLowerCase() !== q);
+    if (!q) return options.slice(0, MAX_VISIBLE);
+    return options
+      .filter((a) => a.toLowerCase().includes(q) && a.toLowerCase() !== q)
+      .slice(0, MAX_VISIBLE);
   }, [options, value]);
 
-  const visible = filtered.slice(0, MAX_VISIBLE);
+  const labelId = `${id}-label`;
 
-  // Highlight reset lives inside each handler that mutates value or open
-  // (avoids react-hooks/set-state-in-effect). The trade-off: a caller that
-  // programmatically swaps `value` won't reset focusedIdx — but `value` is
-  // bounded to [-1, visible.length - 1] anyway and ArrowUp/Down wrap around.
-  const handleChange = (next: string) => {
-    setFocusedIdx(-1);
-    onChange(next);
-  };
-
-  const openPopover = () => {
-    if (blurTimeoutRef.current !== null) {
-      window.clearTimeout(blurTimeoutRef.current);
-      blurTimeoutRef.current = null;
-    }
-    setOpen(true);
-    setFocusedIdx(-1);
-  };
-
-  const closePopover = () => {
-    setOpen(false);
-    setFocusedIdx(-1);
-  };
-
-  const scheduleBlurClose = () => {
-    if (blurTimeoutRef.current !== null) {
-      window.clearTimeout(blurTimeoutRef.current);
-    }
-    blurTimeoutRef.current = window.setTimeout(() => {
-      blurTimeoutRef.current = null;
-      closePopover();
-    }, BLUR_CLOSE_DELAY_MS);
-  };
-
-  const select = (a: string) => {
-    onChange(a);
-    closePopover();
-  };
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "ArrowDown") {
-      e.preventDefault();
-      if (!open) setOpen(true);
-      setFocusedIdx((i) => (visible.length === 0 ? -1 : (i + 1) % visible.length));
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault();
-      if (!open) setOpen(true);
-      setFocusedIdx((i) => {
-        if (visible.length === 0) return -1;
-        return i <= 0 ? visible.length - 1 : i - 1;
-      });
-    } else if (e.key === "Enter" && open && focusedIdx >= 0) {
-      const choice = visible[focusedIdx];
-      if (choice) {
-        e.preventDefault();
-        select(choice);
+  const {
+    isOpen,
+    openMenu,
+    getMenuProps,
+    getInputProps,
+    getItemProps,
+    highlightedIndex
+  } = useCombobox<string>({
+    items: filtered,
+    inputValue: value ?? "",
+    onInputValueChange: ({ inputValue }) => onChange(inputValue ?? ""),
+    onSelectedItemChange: ({ selectedItem }) => {
+      if (selectedItem != null) onChange(selectedItem);
+    },
+    itemToString: (item) => item ?? "",
+    // Click default in v9 toggles open; with onFocus opening too the user
+    // sees the list flicker shut on first click after focus. Pin click
+    // to always open.
+    stateReducer: (_state, { type, changes }) => {
+      if (type === useCombobox.stateChangeTypes.InputClick) {
+        return { ...changes, isOpen: true };
       }
-    } else if (e.key === "Escape" && open) {
-      e.preventDefault();
-      closePopover();
+      return changes;
     }
-  };
-
-  const listId = `${id}-combo-list`;
+  });
 
   return (
     <div className="grid gap-1.5 relative">
-      <Label htmlFor={id}>{label}</Label>
+      <Label id={labelId} htmlFor={id}>{label}</Label>
       <Input
-        id={id}
-        name={id}
-        type="text"
-        autoComplete="off"
-        placeholder={options.length > 0 ? populatedPlaceholder : emptyPlaceholder}
-        role="combobox"
-        aria-expanded={open}
-        aria-controls={listId}
-        aria-activedescendant={open && focusedIdx >= 0 ? `${id}-opt-${focusedIdx}` : undefined}
-        value={value ?? ""}
-        onChange={(e) => handleChange(e.target.value)}
-        onFocus={openPopover}
-        onBlur={scheduleBlurClose}
-        onKeyDown={handleKeyDown}
+        {...getInputProps({
+          id,
+          name: id,
+          type: "text",
+          autoComplete: "off",
+          placeholder: options.length > 0 ? populatedPlaceholder : emptyPlaceholder,
+          // Point aria-labelledby at the visible <Label> so a11y + tests
+          // resolve a single name source.
+          "aria-labelledby": labelId,
+          // Open the list on focus so users can preview existing assets
+          // without typing — matches the prior custom behavior.
+          onFocus: () => openMenu()
+        })}
       />
-      {open && visible.length > 0 && (
+      {isOpen && filtered.length > 0 && (
         <ul
-          id={listId}
-          role="listbox"
+          {...getMenuProps()}
           className="absolute inset-x-0 top-full mt-1 z-20 max-h-60 overflow-y-auto rounded-lg border border-border bg-popover p-1 shadow-lg"
         >
-          {visible.map((a, idx) => (
-            <li key={a} id={`${id}-opt-${idx}`} role="option" aria-selected={focusedIdx === idx}>
-              <button
-                type="button"
-                className={`w-full text-left rounded-md px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground ${focusedIdx === idx ? "bg-accent text-accent-foreground" : ""}`}
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  select(a);
-                }}
-              >
-                {a}
-              </button>
+          {filtered.map((a, idx) => (
+            <li
+              key={a}
+              {...getItemProps({ item: a, index: idx })}
+              className={`cursor-pointer rounded-md px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground ${
+                highlightedIndex === idx ? "bg-accent text-accent-foreground" : ""
+              }`}
+            >
+              {a}
             </li>
           ))}
         </ul>
+      )}
+      {/*
+        downshift v9 wants getMenuProps called on initial render for the ref.
+        When closed we render a hidden ul as a placeholder to satisfy the
+        ref requirement without surfacing role=listbox.
+      */}
+      {!(isOpen && filtered.length > 0) && (
+        <ul {...getMenuProps({}, { suppressRefError: true })} hidden />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Replace bespoke keyboard nav in [AssetCombobox](frontend/src/features/transactions/AssetCombobox.tsx) with [downshift](https://www.downshift-js.com/)'s `useCombobox` hook. Closes the medium-priority autocomplete item from #57.

## Why

Hand-rolled combobox keyboard handling is a known footgun: focus traps, ARIA gaps, edge cases on Home/End/typeahead. The old impl carried ~80 lines of manual open/blur/highlightedIndex/ArrowUp/Down/Enter/Escape logic plus a blur-close `setTimeout` with explicit cleanup. downshift covers all of that, is ~7 kB gz, no styling baggage, headless.

## Changes

- New dep: `downshift` ^9.x. Added to [package.json](frontend/package.json), lockfile updated.
- [AssetCombobox.tsx](frontend/src/features/transactions/AssetCombobox.tsx) rewritten:
  - `useCombobox` with controlled `inputValue` so react-hook-form `Controller` continues to drive value.
  - `stateReducer` pins `isOpen=true` on `InputClick` — prevents click-after-focus from toggling closed.
  - `onFocus: () => openMenu()` opens the list on focus (matches prior behavior).
  - `aria-labelledby` on the input points at the visible `<Label id>` so AT and testing-library resolve a single name source.
  - Hidden `<ul {...getMenuProps({}, { suppressRefError: true })} hidden />` satisfies downshift's ref requirement when the visible menu is conditionally rendered (closed state).
- [App.test.tsx](frontend/src/App.test.tsx):
  - `getByLabelText("Asset")` → `getByRole("combobox", { name: "Asset" })`. Stricter — checks both role and accessible name.
  - Click target in selection test: `getByRole("button", { name: "ETF-A" })` → `getByRole("option", { name: "ETF-A" })`. Items are now `<li role=option>` directly, no `<button>` wrapper.

## Review

Spawned 1 Sonnet reviewer (CLAUDE.md gate; ~127 lines diff, no security/auth). Verdict: **pass**. 3 cosmetic suggestions (redundant `aria-labelledby` + `htmlFor` pair, defensive `suppressRefError`, slice-before-filter semantics) — none blocking, kept as-is.

## Test plan

- [x] `npm test` (frontend): 48 / 48 pass — including the 3 combobox kbd-nav tests updated to use role queries.
- [x] `npm run test:unit` (backend): 125 / 125 pass.
- [x] `npm run typecheck` clean.
- [x] `npm run build` clean.
- [x] Manual browser: click input opens list, ArrowDown+ArrowDown+Enter selected `revolut`. Confirmed via DOM (`aria-expanded=true`, 2 options rendered, input value updated).

Closes part of #57 (medium: autocomplete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)