### PR TITLE
refactor(frontend): extract shared okSchema to lib

### DIFF
--- a/frontend/src/features/auth/useChangePasswordMutation.ts
+++ b/frontend/src/features/auth/useChangePasswordMutation.ts
@@ -1,10 +1,8 @@
 import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { z } from "zod";
-import { apiEnvelopeSchema, apiFetch } from "@/lib";
+import { apiFetch, okSchema } from "@/lib";
 import type { ChangePasswordValues } from "./schemas";
 
-const okSchema = apiEnvelopeSchema(z.object({ ok: z.boolean() }));
 
 export function useChangePasswordMutation(onAfterSuccess?: () => void) {
   return useMutation({

--- a/frontend/src/features/auth/useLogoutMutation.ts
+++ b/frontend/src/features/auth/useLogoutMutation.ts
@@ -1,9 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { z } from "zod";
-import { apiEnvelopeSchema, apiFetch } from "@/lib";
+import { apiFetch, okSchema } from "@/lib";
 import { useAuthStore } from "@/shared/auth/authStore";
 
-const okSchema = apiEnvelopeSchema(z.object({ ok: z.boolean() }));
 
 export function useLogoutMutation() {
   const queryClient = useQueryClient();

--- a/frontend/src/features/dashboard/DashboardPanel.tsx
+++ b/frontend/src/features/dashboard/DashboardPanel.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { apiEnvelopeSchema, apiFetch } from "../../lib";
-import { z } from "zod";
+import { apiFetch, okSchema } from "../../lib";
 import {
   mmListResponse,
   prefsResponse,
@@ -21,7 +20,6 @@ import { AssetPnlChart } from "./AssetPnlChart";
 import { ZeroAssetsToggle } from "./ZeroAssetsToggle";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-const okSchema = apiEnvelopeSchema(z.object({ ok: z.boolean() }));
 
 export function DashboardPanel() {
   const queryClient = useQueryClient();

--- a/frontend/src/features/movements/useDeleteMovement.ts
+++ b/frontend/src/features/movements/useDeleteMovement.ts
@@ -1,8 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { z } from "zod";
-import { apiEnvelopeSchema, apiFetch } from "@/lib";
+import { apiFetch, okSchema } from "@/lib";
 
-const okSchema = apiEnvelopeSchema(z.object({ ok: z.boolean() }));
 
 export function useDeleteMovement() {
   const queryClient = useQueryClient();

--- a/frontend/src/features/movements/useMmMutation.ts
+++ b/frontend/src/features/movements/useMmMutation.ts
@@ -1,10 +1,9 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { z } from "zod";
-import { apiEnvelopeSchema, apiFetch } from "@/lib";
+import { apiEnvelopeSchema, apiFetch, okSchema } from "@/lib";
 import { mmFormSchema, type MmFormValues } from "./schemas";
 
 const createSchema = apiEnvelopeSchema(z.object({ id: z.string() }));
-const okSchema = apiEnvelopeSchema(z.object({ ok: z.boolean() }));
 
 export function useMmMutation(editingId: string | null, onAfterSuccess: () => void) {
   const queryClient = useQueryClient();

--- a/frontend/src/features/settings/useBackupActions.ts
+++ b/frontend/src/features/settings/useBackupActions.ts
@@ -1,6 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { z } from "zod";
-import { apiEnvelopeSchema, apiFetch } from "@/lib";
+import { apiEnvelopeSchema, apiFetch, okSchema } from "@/lib";
 
 function downloadBlob(blob: Blob, filename: string) {
   const a = document.createElement("a");
@@ -16,7 +16,6 @@ function dateStamp(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-const okSchema = apiEnvelopeSchema(z.object({ ok: z.boolean() }));
 const anySchema = apiEnvelopeSchema(z.any());
 
 export function useBackupActions() {

--- a/frontend/src/features/settings/usePreferences.ts
+++ b/frontend/src/features/settings/usePreferences.ts
@@ -1,9 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { z } from "zod";
-import { apiEnvelopeSchema, apiFetch } from "@/lib";
+import { apiFetch, okSchema } from "@/lib";
 import { prefsResponse } from "@/types";
 
-const okSchema = apiEnvelopeSchema(z.object({ ok: z.boolean() }));
 
 export function usePreferencesQuery(enabled: boolean) {
   return useQuery({

--- a/frontend/src/features/settings/usePurgeMutation.ts
+++ b/frontend/src/features/settings/usePurgeMutation.ts
@@ -1,8 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { z } from "zod";
-import { apiEnvelopeSchema, apiFetch } from "@/lib";
+import { apiFetch, okSchema } from "@/lib";
 
-const okSchema = apiEnvelopeSchema(z.object({ ok: z.boolean() }));
 
 export function usePurgeMutation(onSuccess?: () => void) {
   const queryClient = useQueryClient();

--- a/frontend/src/features/settings/useStylesMutation.ts
+++ b/frontend/src/features/settings/useStylesMutation.ts
@@ -1,9 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { z } from "zod";
-import { apiEnvelopeSchema, apiFetch } from "@/lib";
+import { apiFetch, okSchema } from "@/lib";
 import { stylesResponse, type StylesMap } from "@/types";
 
-const okSchema = apiEnvelopeSchema(z.object({ ok: z.boolean() }));
 
 export function useStylesQuery(enabled: boolean) {
   return useQuery({

--- a/frontend/src/features/snapshots/useDeleteSnapshot.ts
+++ b/frontend/src/features/snapshots/useDeleteSnapshot.ts
@@ -1,8 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { z } from "zod";
-import { apiEnvelopeSchema, apiFetch } from "@/lib";
+import { apiFetch, okSchema } from "@/lib";
 
-const okSchema = apiEnvelopeSchema(z.object({ ok: z.boolean() }));
 
 export function useDeleteSnapshot() {
   const queryClient = useQueryClient();

--- a/frontend/src/features/transactions/useDeleteTransaction.ts
+++ b/frontend/src/features/transactions/useDeleteTransaction.ts
@@ -1,8 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { z } from "zod";
-import { apiEnvelopeSchema, apiFetch } from "@/lib";
+import { apiFetch, okSchema } from "@/lib";
 
-const okSchema = apiEnvelopeSchema(z.object({ ok: z.boolean() }));
 
 export function useDeleteTransaction() {
   const queryClient = useQueryClient();

--- a/frontend/src/features/transactions/useTxMutation.ts
+++ b/frontend/src/features/transactions/useTxMutation.ts
@@ -1,10 +1,9 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { z } from "zod";
-import { apiEnvelopeSchema, apiFetch } from "@/lib";
+import { apiEnvelopeSchema, apiFetch, okSchema } from "@/lib";
 import { txFormSchema, tipoShowsBuyValue, tipoShowsPnl, type TxFormValues } from "./schemas";
 
 const createSchema = apiEnvelopeSchema(z.object({ id: z.string() }));
-const okSchema = apiEnvelopeSchema(z.object({ ok: z.boolean() }));
 
 function buildPayload(values: TxFormValues) {
   const parsed = txFormSchema.parse(values);

--- a/frontend/src/lib.ts
+++ b/frontend/src/lib.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 
 export const apiEnvelopeSchema = <T extends z.ZodTypeAny>(schema: T) => z.object({ data: schema });
 
+export const okSchema = apiEnvelopeSchema(z.object({ ok: z.boolean() }));
+
 export async function apiFetch<T>(
   path: string,
   options: RequestInit,


### PR DESCRIPTION
## Summary

Deferred finding from #93: the api-envelope `okSchema` for `{ ok: boolean }` responses was redefined identically in 12 frontend modules. This extracts it once into `lib.ts` and imports it everywhere.

- `frontend/src/lib.ts`: export `okSchema = apiEnvelopeSchema(z.object({ ok: z.boolean() }))`
- 12 modules: drop the local `okSchema` const, import it from `lib`, and remove the now-unused `apiEnvelopeSchema` / `zod` imports where they were only used for it.

`useSnapMutation.ts` keeps its own local `okSchema` — it validates `{ id: string }`, a different shape, so it is intentionally untouched.

## Verification

- `tsc --noEmit`: clean
- frontend unit tests: 48/48 pass
- lint: unchanged (the 4 pre-existing errors in `router.tsx` exist on `main` too; CI does not run lint)

## Scope

Addresses only the okSchema-duplication finding. The other deferred findings in #93 (form-schema number types, `z.any()` backup schema, hardcoded sibling prefixes, N+1 inserts) remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)