### PR TITLE
refactor: address deferred findings from #93 (form types, backup schema, legacy cleanup)

### DIFF
--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -61,13 +61,60 @@ export const stylesSchema = z.object({
 
 export const prefsSchema = z.object({ showZeroAssets: z.boolean() });
 
+// Sub-schemas reflect fields actually read by applyImport.
+// .passthrough() keeps unknown fields so older/newer backups still import.
+const txImportRow = z
+  .object({
+    id: z.unknown().optional(),
+    date: z.unknown().optional(),
+    txDate: z.unknown().optional(),
+    asset: z.unknown().optional(),
+    tipo: z.unknown().optional(),
+    derivedType: z.unknown().optional(),
+    type: z.unknown().optional(),
+    buyValue: z.unknown().optional(),
+    pnl: z.unknown().optional(),
+    currentValue: z.unknown().optional(),
+    note: z.unknown().optional()
+  })
+  .passthrough();
+
+const mmImportRow = z
+  .object({
+    id: z.unknown().optional(),
+    name: z.unknown().optional(),
+    direction: z.unknown().optional(),
+    amount: z.unknown().optional(),
+    note: z.unknown().optional()
+  })
+  .passthrough();
+
+const snapImportRow = z
+  .object({
+    id: z.unknown().optional(),
+    date: z.unknown().optional(),
+    snapshotDate: z.unknown().optional(),
+    low: z.unknown().optional(),
+    lowRisk: z.unknown().optional(),
+    medium: z.unknown().optional(),
+    mediumRisk: z.unknown().optional(),
+    high: z.unknown().optional(),
+    highRisk: z.unknown().optional(),
+    liquid: z.unknown().optional()
+  })
+  .passthrough();
+
+const prefsImportRow = z
+  .object({ showZeroAssets: z.unknown().optional() })
+  .passthrough();
+
 export const backupImportSchema = z.object({
-  transactions: z.array(z.record(z.string(), z.any())).max(50_000).optional(),
-  monthlyMovements: z.array(z.record(z.string(), z.any())).max(50_000).optional(),
-  monthlySnapshots: z.array(z.record(z.string(), z.any())).max(50_000).optional(),
+  transactions: z.array(txImportRow).max(50_000).optional(),
+  monthlyMovements: z.array(mmImportRow).max(50_000).optional(),
+  monthlySnapshots: z.array(snapImportRow).max(50_000).optional(),
   assetColors: z.record(z.string(), z.string()).optional(),
   assetRisks: z.record(z.string(), z.string()).optional(),
-  preferences: z.record(z.string(), z.any()).optional()
+  preferences: prefsImportRow.optional()
 });
 
 export type ApiEnv = {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -70,18 +70,6 @@ const server = Bun.serve({
       );
     }
 
-    // Routes reserved for sibling apps in the same reverse-proxy namespace.
-    // Return 404 JSON instead of falling through to the SPA index.
-    const SIBLING_APP_PREFIXES = ["/hub", "/myhealth", "/mymoney"];
-    if (SIBLING_APP_PREFIXES.some((p) => url.pathname === p || url.pathname.startsWith(`${p}/`))) {
-      const headers = new Headers({ "content-type": "application/json" });
-      applySecurityHeaders(headers);
-      return new Response(
-        JSON.stringify({ error: { code: "NOT_FOUND", message: "Route not found" } }),
-        { status: 404, headers }
-      );
-    }
-
     const staticFile = resolveStaticFile(env.PUBLIC_DIR, url.pathname);
     if (staticFile) {
       const headers = new Headers();

--- a/frontend/src/features/snapshots/SnapshotForm.tsx
+++ b/frontend/src/features/snapshots/SnapshotForm.tsx
@@ -2,12 +2,12 @@ import { type UseFormReturn } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Field } from "@/shared/ui/Field";
-import type { SnapFormValues } from "./schemas";
+import type { SnapFormDefaults } from "./schemas";
 
 type Props = {
-  form: UseFormReturn<SnapFormValues>;
+  form: UseFormReturn<SnapFormDefaults>;
   disabled: boolean;
-  onSubmit: (values: SnapFormValues) => void;
+  onSubmit: (values: SnapFormDefaults) => void;
 };
 
 export function SnapshotForm({ form, disabled, onSubmit }: Props) {

--- a/frontend/src/features/snapshots/SnapshotsPanel.tsx
+++ b/frontend/src/features/snapshots/SnapshotsPanel.tsx
@@ -10,12 +10,11 @@ import { SnapshotsTable } from "./SnapshotsTable";
 import { useSnapshotsQuery } from "./useSnapshotsQuery";
 import { useSnapMutation } from "./useSnapMutation";
 import { useDeleteSnapshot } from "./useDeleteSnapshot";
-import { type SnapFormValues } from "./schemas";
+import { type SnapFormDefaults } from "./schemas";
 
-const snapDefaults: SnapFormValues = {
+const snapDefaults: SnapFormDefaults = {
   snapshotDate: new Date().toISOString().slice(0, 10),
-  // empty string renders placeholder in number input; z.coerce.number maps "" → 0 at submit
-  liquid: "" as unknown as number
+  liquid: ""
 };
 
 export function SnapshotsPanel() {
@@ -36,12 +35,12 @@ export function SnapshotsPanel() {
       apiFetch("/api/v1/assets/styles", { method: "GET", signal }, (raw) => stylesResponse.parse(raw).data)
   });
 
-  const form = useForm<SnapFormValues>({
+  const form = useForm<SnapFormDefaults>({
     defaultValues: { ...snapDefaults }
   });
 
   const snapMutation = useSnapMutation(() => {
-    form.reset({ snapshotDate: new Date().toISOString().slice(0, 10), liquid: "" as unknown as number });
+    form.reset({ snapshotDate: new Date().toISOString().slice(0, 10), liquid: "" });
   });
   const deleteMutation = useDeleteSnapshot();
 

--- a/frontend/src/features/snapshots/schemas.test.ts
+++ b/frontend/src/features/snapshots/schemas.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "vitest";
+import { snapFormSchema } from "./schemas";
+
+describe("snapFormSchema", () => {
+  test("coerces empty string liquid to 0 on submit", () => {
+    const result = snapFormSchema.parse({ snapshotDate: "2026-01-31", liquid: "" });
+    expect(result.liquid).toBe(0);
+  });
+
+  test("preserves numeric liquid value when present", () => {
+    const result = snapFormSchema.parse({ snapshotDate: "2026-01-31", liquid: 500 });
+    expect(result.liquid).toBe(500);
+  });
+});

--- a/frontend/src/features/snapshots/schemas.ts
+++ b/frontend/src/features/snapshots/schemas.ts
@@ -6,3 +6,9 @@ export const snapFormSchema = z.object({
 });
 
 export type SnapFormValues = z.infer<typeof snapFormSchema>;
+
+/** Default values for useForm. liquid accepts "" so the input renders
+ *  a placeholder; z.coerce.number maps "" → 0 when the form is submitted. */
+export type SnapFormDefaults = Omit<SnapFormValues, "liquid"> & {
+  liquid: number | "";
+};

--- a/frontend/src/features/snapshots/useSnapMutation.ts
+++ b/frontend/src/features/snapshots/useSnapMutation.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { apiEnvelopeSchema, apiFetch } from "@/lib";
 import type { StylesMap, Transaction } from "@/types";
 import { computePerAsset } from "@/lib/dashboard";
-import { snapFormSchema, type SnapFormValues } from "./schemas";
+import { snapFormSchema, type SnapFormDefaults } from "./schemas";
 
 const okSchema = apiEnvelopeSchema(z.object({ id: z.string() }));
 
@@ -19,7 +19,7 @@ const round2 = (n: number) => Math.round(n * 100) / 100;
 export function useSnapMutation(onAfterSuccess: () => void) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (values: SnapFormValues) => {
+    mutationFn: async (values: SnapFormDefaults) => {
       const form = snapFormSchema.parse(values);
       const transactions = queryClient.getQueryData<Transaction[]>(["transactions"]);
       const stylesMap = queryClient.getQueryData<StylesMap>(["styles"]);

--- a/frontend/src/features/transactions/TransactionForm.tsx
+++ b/frontend/src/features/transactions/TransactionForm.tsx
@@ -15,15 +15,15 @@ import {
   TIPO_OPTIONS,
   tipoShowsBuyValue,
   tipoShowsPnl,
-  type TxFormValues
+  type TxFormDefaults
 } from "./schemas";
 
 type Props = {
-  form: UseFormReturn<TxFormValues>;
+  form: UseFormReturn<TxFormDefaults>;
   assetOptions: string[];
   editingId: string | null;
   isSubmitting: boolean;
-  onSubmit: (values: TxFormValues) => void;
+  onSubmit: (values: TxFormDefaults) => void;
   onCancel: () => void;
 };
 

--- a/frontend/src/features/transactions/TransactionsPanel.tsx
+++ b/frontend/src/features/transactions/TransactionsPanel.tsx
@@ -6,13 +6,13 @@ import { TransactionsTable } from "./TransactionsTable";
 import { useTransactionsQuery } from "./useTransactionsQuery";
 import { useTxMutation } from "./useTxMutation";
 import { useDeleteTransaction } from "./useDeleteTransaction";
-import { txFormDefaults, type TxFormValues } from "./schemas";
+import { txFormDefaults, type TxFormDefaults } from "./schemas";
 
 export function TransactionsPanel() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const txQuery = useTransactionsQuery(true);
 
-  const form = useForm<TxFormValues>({ defaultValues: txFormDefaults });
+  const form = useForm<TxFormDefaults>({ defaultValues: txFormDefaults });
 
   const txMutation = useTxMutation(editingId, () => {
     setEditingId(null);

--- a/frontend/src/features/transactions/schemas.test.ts
+++ b/frontend/src/features/transactions/schemas.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+import { txFormSchema, txFormDefaults } from "./schemas";
+
+describe("txFormSchema", () => {
+  test("coerces empty string buyValue to 0 on submit", () => {
+    const result = txFormSchema.parse({ ...txFormDefaults, asset: "ETF-A", buyValue: "", pnl: "" });
+    expect(result.buyValue).toBe(0);
+    expect(result.pnl).toBe(0);
+  });
+
+  test("preserves numeric values when present", () => {
+    const result = txFormSchema.parse({ ...txFormDefaults, asset: "ETF-A", buyValue: 100, pnl: 5.5 });
+    expect(result.buyValue).toBe(100);
+    expect(result.pnl).toBe(5.5);
+  });
+
+  test("txFormDefaults has no as-unknown-as casts — types are assignable without assertion", () => {
+    // If TxFormDefaults is used correctly, buyValue and pnl are typed as number|""
+    // This test verifies the runtime value is "" (not an invalid cast).
+    expect(txFormDefaults.buyValue).toBe("");
+    expect(txFormDefaults.pnl).toBe("");
+  });
+});

--- a/frontend/src/features/transactions/schemas.ts
+++ b/frontend/src/features/transactions/schemas.ts
@@ -30,12 +30,18 @@ export const txFormSchema = z.object({
 
 export type TxFormValues = z.infer<typeof txFormSchema>;
 
-export const txFormDefaults: TxFormValues = {
+/** Default values for useForm. Number fields accept "" so the input renders
+ *  a placeholder; z.coerce.number maps "" → 0 when the form is submitted. */
+export type TxFormDefaults = Omit<TxFormValues, "buyValue" | "pnl"> & {
+  buyValue: number | "";
+  pnl: number | "";
+};
+
+export const txFormDefaults: TxFormDefaults = {
   txDate: new Date().toISOString().slice(0, 10),
   asset: "",
   tipo: "nuovo vincolo",
-  // empty string renders placeholder in number input; z.coerce.number maps "" → 0 at submit
-  buyValue: "" as unknown as number,
-  pnl: "" as unknown as number,
+  buyValue: "",
+  pnl: "",
   note: ""
 };

--- a/frontend/src/features/transactions/useTxMutation.ts
+++ b/frontend/src/features/transactions/useTxMutation.ts
@@ -1,11 +1,11 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { z } from "zod";
 import { apiEnvelopeSchema, apiFetch, okSchema } from "@/lib";
-import { txFormSchema, tipoShowsBuyValue, tipoShowsPnl, type TxFormValues } from "./schemas";
+import { txFormSchema, tipoShowsBuyValue, tipoShowsPnl, type TxFormDefaults } from "./schemas";
 
 const createSchema = apiEnvelopeSchema(z.object({ id: z.string() }));
 
-function buildPayload(values: TxFormValues) {
+function buildPayload(values: TxFormDefaults) {
   const parsed = txFormSchema.parse(values);
   const buyValue = tipoShowsBuyValue(parsed.tipo) ? Number(parsed.buyValue) : 0;
   const pnl = tipoShowsPnl(parsed.tipo) ? Number(parsed.pnl) : 0;
@@ -23,7 +23,7 @@ function buildPayload(values: TxFormValues) {
 export function useTxMutation(editingId: string | null, onAfterSuccess: () => void) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (values: TxFormValues) => {
+    mutationFn: async (values: TxFormDefaults) => {
       const payload = buildPayload(values);
       if (editingId) {
         return apiFetch(


### PR DESCRIPTION
## Summary

Three deferred findings from #93:

1. **form-schema number types** — replaced all `"" as unknown as number` casts with an honest `number | ""` union for the form *default-values* type (`TxFormDefaults` / `SnapFormDefaults`), keeping the strict zod-inferred submission type. Propagated through transactions + snapshots forms/panels/mutations.
2. **backup import schema** — replaced `z.record(z.string(), z.any())` with typed row sub-schemas using `.passthrough()` (chosen over `.strict()` so older/newer backups still import).
3. **legacy cleanup** — removed the dead hardcoded sibling-app prefix guard (`["/hub", "/myhealth", "/mymoney"]`) in `server.ts`, leftover from when health and money were one app. Verified dead before removal.

## Verification

- `tsc --noEmit`: clean
- frontend tests: 53/53 pass · backend tests: 139/139 pass
- Reviewed by a subagent against AGENTS.md (verdict: pass, no blockers)

## Scope

Addresses #93 (other findings — okSchema already done in #95; N+1 inserts remain open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)