### PR TITLE
fix: default COOKIE_SECURE to false for plain-HTTP self-hosting

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -17,12 +17,22 @@ const envSchema = z.object({
     .string()
     .default("http://localhost:5174,http://127.0.0.1:5174,http://localhost:8001,http://127.0.0.1:8001"),
   PUBLIC_DIR: z.string().default(path.resolve(process.cwd(), "../frontend/dist")),
+  // Default false so a plain-HTTP self-hosted LAN instance works out of the
+  // box. Internet-facing deployments must serve over HTTPS and set
+  // COOKIE_SECURE=true, otherwise the session cookie travels without the
+  // Secure flag and can be intercepted.
   COOKIE_SECURE: z.string().default("false"),
   LOGIN_RATE_LIMIT_MAX: z.coerce.number().default(5),
   LOGIN_RATE_LIMIT_WINDOW_SECONDS: z.coerce.number().default(15 * 60)
 });
 
 const env = envSchema.parse(process.env);
+
+if (env.COOKIE_SECURE.toLowerCase() !== "true") {
+  console.warn(
+    "⚠️  COOKIE_SECURE is disabled: session cookies are sent without the Secure flag. Use HTTPS and set COOKIE_SECURE=true for internet-facing deployments."
+  );
+}
 
 fs.mkdirSync(path.dirname(env.DB_PATH), { recursive: true });
 const db = openDb(env.DB_PATH);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -17,7 +17,7 @@ const envSchema = z.object({
     .string()
     .default("http://localhost:5174,http://127.0.0.1:5174,http://localhost:8001,http://127.0.0.1:8001"),
   PUBLIC_DIR: z.string().default(path.resolve(process.cwd(), "../frontend/dist")),
-  COOKIE_SECURE: z.string().default("true"),
+  COOKIE_SECURE: z.string().default("false"),
   LOGIN_RATE_LIMIT_MAX: z.coerce.number().default(5),
   LOGIN_RATE_LIMIT_WINDOW_SECONDS: z.coerce.number().default(15 * 60)
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       PORT: 8001
       DB_PATH: /app/data/mymoney.sqlite
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost:8001,http://127.0.0.1:8001,http://localhost:5174,http://127.0.0.1:5174}
-      COOKIE_SECURE: "true"
+      COOKIE_SECURE: "${COOKIE_SECURE:-false}"
     volumes:
       - ./data:/app/data
     restart: unless-stopped


### PR DESCRIPTION
## Why

Logging in over plain HTTP (e.g. `http://host:3333` on a LAN) looped back to the login page. Root cause: the session cookie was marked `Secure` by default — env default `\"true\"` in `server.ts` plus a hardcoded `\"true\"` in `docker-compose.yml`. Browsers silently drop `Secure` cookies on non-HTTPS connections, so the server set the cookie but the browser discarded it → every subsequent request looked unauthenticated.

## What

- `backend/src/server.ts`: zod default for `COOKIE_SECURE` is now `"false"` (covers running the backend without Docker too).
- `docker-compose.yml`: reads `COOKIE_SECURE` from the environment (`${COOKIE_SECURE:-false}`) instead of hardcoding `"true"`.

A freshly cloned instance now works over plain HTTP on a trusted LAN out of the box. Deployments behind HTTPS opt back in with `COOKIE_SECURE=true`.

## Trade-off

Security is now opt-in: an instance exposed to the internet without HTTPS would transmit the session cookie in the clear. Acceptable for the intended self-hosted LAN use; documented here so the choice is explicit.

## Test plan

- `npm run typecheck` — pass
- `npm run test:unit` — 139 pass / 0 fail
- Live server recreated with `COOKIE_SECURE=false`; container healthy, HTTP 200; login no longer loops.