### PR TITLE
fix: codebase analysis findings 2026-06-13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ desktop.ini
 .vscode/
 .idea/
 .claude/
+*.bak

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM oven/bun:1.3.14 AS frontend-build
 WORKDIR /app/frontend
 COPY frontend/package.json frontend/package-lock.json* ./
-RUN bun install
+RUN bun install --frozen-lockfile
 COPY frontend/ ./
 RUN bun run build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # renovate: datasource=docker depName=oven/bun
 FROM oven/bun:1.3.14 AS frontend-build
 WORKDIR /app/frontend
-COPY frontend/package.json frontend/package-lock.json* ./
+COPY frontend/package.json frontend/package-lock.json* frontend/bun.lock* ./
 RUN bun install --frozen-lockfile
 COPY frontend/ ./
 RUN bun run build

--- a/backend/src/api/auth.ts
+++ b/backend/src/api/auth.ts
@@ -2,6 +2,7 @@ import { Hono, type Context } from "hono";
 import { getCookie } from "hono/cookie";
 
 import { eq, sql } from "drizzle-orm";
+import { nowUnixSeconds } from "../helpers.ts";
 import { getDrizzle } from "../db.ts";
 import { users, user_sessions } from "../db/schema.ts";
 import { changePasswordSchema, loginSchema } from "../schemas.ts";
@@ -111,34 +112,25 @@ authRoutes.get("/session", (c) => {
   const sid = getCookie(c, env.SESSION_COOKIE_NAME);
   if (!sid) return jsonData(c, { authenticated: false });
   const dbo = getDrizzle(db);
-  const now = Math.floor(Date.now() / 1000);
-  const sessionRow = dbo
+  const row = dbo
     .select({
-      user_id: user_sessions.user_id,
-      expires_at: user_sessions.expires_at
-    })
-    .from(user_sessions)
-    .where(eq(user_sessions.sid, sid))
-    .limit(1)
-    .get();
-  if (!sessionRow || Number(sessionRow.expires_at) <= now) {
-    return jsonData(c, { authenticated: false });
-  }
-  const user = dbo
-    .select({
+      expires_at: user_sessions.expires_at,
       id: users.id,
       email: users.email,
       name: users.name,
       disabled_at: users.disabled_at
     })
-    .from(users)
-    .where(eq(users.id, Number(sessionRow.user_id)))
+    .from(user_sessions)
+    .innerJoin(users, eq(users.id, user_sessions.user_id))
+    .where(eq(user_sessions.sid, sid))
     .limit(1)
     .get();
-  if (!user || user.disabled_at) return jsonData(c, { authenticated: false });
+  if (!row || Number(row.expires_at) <= nowUnixSeconds() || row.disabled_at) {
+    return jsonData(c, { authenticated: false });
+  }
   return jsonData(c, {
     authenticated: true,
-    user: { id: user.id, email: user.email, name: user.name ?? null }
+    user: { id: row.id, email: row.email, name: row.name ?? null }
   });
 });
 

--- a/backend/src/api/backup-helpers.ts
+++ b/backend/src/api/backup-helpers.ts
@@ -194,12 +194,15 @@ export function applyImport(db: SQLiteDB, userId: number, payload: ImportPayload
       ...Object.keys(payload.assetColors),
       ...Object.keys(payload.assetRisks)
     ]);
-    const styleRows = Array.from(assets).map((asset) => ({
-      user_id: userId,
-      asset,
-      color_hex: payload.assetColors[asset] ?? null,
-      risk_level: payload.assetRisks[asset] ?? null
-    }));
+    // Validate and truncate asset keys to match schema constraint (1-120 chars).
+    const styleRows = Array.from(assets)
+      .filter((asset) => asset.length >= 1 && asset.length <= 120)
+      .map((asset) => ({
+        user_id: userId,
+        asset,
+        color_hex: payload.assetColors[asset] ?? null,
+        risk_level: payload.assetRisks[asset] ?? null
+      }));
     if (styleRows.length > 0) {
       dbo.insert(asset_styles).values(styleRows).onConflictDoNothing().run();
     }

--- a/backend/src/api/backup-helpers.ts
+++ b/backend/src/api/backup-helpers.ts
@@ -115,7 +115,10 @@ export function wipeUserData(
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 function toIsoDateOrNull(v: unknown): string | null {
   const s = String(v ?? "").slice(0, 10);
-  return ISO_DATE_RE.test(s) && Number.isFinite(Date.parse(s)) ? s : null;
+  // Round-trip through Date to reject invalid calendar dates (e.g. "2023-02-30").
+  if (!ISO_DATE_RE.test(s)) return null;
+  const d = new Date(s);
+  return !isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s ? s : null;
 }
 
 export function applyImport(db: SQLiteDB, userId: number, payload: ImportPayload): void {
@@ -135,7 +138,7 @@ export function applyImport(db: SQLiteDB, userId: number, payload: ImportPayload
         tx_date,
         asset: String(row.asset ?? "").slice(0, 120),
         tipo,
-        derived_type: String(row.derivedType ?? row.type ?? inferType(tipo, buyValue, pnl)),
+        derived_type: String(row.derivedType ?? row.type ?? inferType(tipo, buyValue, pnl)).slice(0, 40),
         buy_value: buyValue,
         pnl,
         current_value: Number.isFinite(Number(row.currentValue)) ? Number(row.currentValue) : buyValue + pnl,
@@ -148,14 +151,21 @@ export function applyImport(db: SQLiteDB, userId: number, payload: ImportPayload
   }
 
   const validDirections = new Set(["income", "expense"]);
-  const mmRows = payload.monthlyMovements.map((row) => ({
-    id: String(row.id ?? makeId("mm")).slice(0, 64),
-    user_id: userId,
-    name: String(row.name ?? "").slice(0, 120),
-    direction: validDirections.has(String(row.direction)) ? String(row.direction) : "income",
-    amount: Math.abs(Number.isFinite(Number(row.amount)) ? Number(row.amount) : 0),
-    note: String(row.note ?? "").slice(0, 2000)
-  }));
+  const mmRows = payload.monthlyMovements
+    .map((row) => {
+      const direction = String(row.direction ?? "");
+      // Rows with unknown direction are skipped rather than silently reclassified.
+      if (!validDirections.has(direction)) return null;
+      return {
+        id: String(row.id ?? makeId("mm")).slice(0, 64),
+        user_id: userId,
+        name: String(row.name ?? "").slice(0, 120),
+        direction,
+        amount: Math.abs(Number.isFinite(Number(row.amount)) ? Number(row.amount) : 0),
+        note: String(row.note ?? "").slice(0, 2000)
+      };
+    })
+    .filter((r): r is NonNullable<typeof r> => r !== null);
   if (mmRows.length > 0) {
     dbo.insert(monthly_movements).values(mmRows).onConflictDoNothing().run();
   }

--- a/backend/src/api/backup.ts
+++ b/backend/src/api/backup.ts
@@ -158,10 +158,13 @@ backupRoutes.post("/xlsx/import", async (c) => {
       return jsonError(c, "INVALID_FILE", "Could not parse file as XLSX", 400);
     }
   } else {
-    const payload = (await c.req.json().catch((e: unknown) => {
+    let payload: { base64?: string } | null = null;
+    try {
+      payload = (await c.req.json()) as { base64?: string };
+    } catch (e: unknown) {
       console.error("[backup] json parse failed:", e);
-      return null;
-    })) as { base64?: string } | null;
+      return jsonError(c, "INVALID_JSON", "Request body is not valid JSON", 400);
+    }
     if (!payload?.base64 || typeof payload.base64 !== "string") {
       return jsonError(
         c,
@@ -255,6 +258,11 @@ purgeRoutes.post("/purge", (c) => {
   const tx = db.transaction(() => {
     wipeUserData(db, user.id, true, true);
   });
-  tx();
+  try {
+    tx();
+  } catch (e) {
+    console.error("[purge] failed:", e);
+    return jsonError(c, "PURGE_FAILED", "Purge failed. Check server logs for details.", 500);
+  }
   return jsonData(c, { ok: true });
 });

--- a/backend/src/api/middleware.ts
+++ b/backend/src/api/middleware.ts
@@ -4,12 +4,14 @@ import { eq } from "drizzle-orm";
 import { getDrizzle } from "../db.ts";
 import { users, user_sessions } from "../db/schema.ts";
 import { applySecurityHeaders } from "../security-headers.ts";
+import { nowUnixSeconds } from "../helpers.ts";
 import type { AppEnv } from "./types.ts";
 import { jsonError } from "./responses.ts";
 
 export const securityHeaders: MiddlewareHandler<AppEnv> = async (c, next) => {
   await next();
-  applySecurityHeaders(c.res.headers);
+  const env = c.get("env");
+  applySecurityHeaders(c.res.headers, env.COOKIE_SECURE.toLowerCase() === "true");
 };
 
 export function originGuard(allowedOriginsCsv: string): MiddlewareHandler<AppEnv> {
@@ -60,14 +62,19 @@ export const sessionGuard: MiddlewareHandler<AppEnv> = async (c, next) => {
     return jsonError(c, "UNAUTHORIZED", "Authentication required", 401);
   }
   const dbo = getDrizzle(db);
-  const now = Math.floor(Date.now() / 1000);
+  const now = nowUnixSeconds();
   const row = dbo
     .select({
-      user_id: user_sessions.user_id,
-      email: user_sessions.email,
-      expires_at: user_sessions.expires_at
+      userId: user_sessions.user_id,
+      sessionEmail: user_sessions.email,
+      expires_at: user_sessions.expires_at,
+      id: users.id,
+      email: users.email,
+      name: users.name,
+      disabled_at: users.disabled_at
     })
     .from(user_sessions)
+    .innerJoin(users, eq(users.id, user_sessions.user_id))
     .where(eq(user_sessions.sid, sid))
     .limit(1)
     .get();
@@ -78,21 +85,10 @@ export const sessionGuard: MiddlewareHandler<AppEnv> = async (c, next) => {
     dbo.delete(user_sessions).where(eq(user_sessions.sid, sid)).run();
     return jsonError(c, "UNAUTHORIZED", "Authentication required", 401);
   }
-  const me = dbo
-    .select({
-      id: users.id,
-      email: users.email,
-      name: users.name,
-      disabled_at: users.disabled_at
-    })
-    .from(users)
-    .where(eq(users.id, Number(row.user_id)))
-    .limit(1)
-    .get();
-  if (!me || me.disabled_at) {
+  if (row.disabled_at) {
     return jsonError(c, "UNAUTHORIZED", "Authentication required", 401);
   }
-  c.set("session", { sid, userId: Number(row.user_id), email: row.email });
-  c.set("user", { id: me.id, email: me.email, name: me.name ?? null });
+  c.set("session", { sid, userId: Number(row.userId), email: row.sessionEmail });
+  c.set("user", { id: row.id, email: row.email, name: row.name ?? null });
   await next();
 };

--- a/backend/src/api/session.ts
+++ b/backend/src/api/session.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import bcrypt from "bcryptjs";
 import { getDrizzle, type SQLiteDB } from "../db.ts";
 import { user_sessions } from "../db/schema.ts";
+import { nowUnixSeconds } from "../helpers.ts";
 import type { ApiEnv } from "../schemas.ts";
 import type { AppEnv } from "./types.ts";
 
@@ -14,7 +15,7 @@ export function createSession(
   ttlSeconds: number
 ): { sid: string; expiresAt: number } {
   const sid = crypto.randomUUID().replaceAll("-", "");
-  const expiresAt = Math.floor(Date.now() / 1000) + ttlSeconds;
+  const expiresAt = nowUnixSeconds() + ttlSeconds;
   getDrizzle(db)
     .insert(user_sessions)
     .values({ sid, user_id: userId, email, expires_at: expiresAt })

--- a/backend/src/api/styles.ts
+++ b/backend/src/api/styles.ts
@@ -5,7 +5,7 @@ import { getDrizzle } from "../db.ts";
 import { asset_styles } from "../db/schema.ts";
 import { stylesSchema } from "../schemas.ts";
 import type { AppEnv } from "./types.ts";
-import { jsonData, validateJson } from "./responses.ts";
+import { jsonData, jsonError, validateJson } from "./responses.ts";
 
 export const stylesRoutes = new Hono<AppEnv>();
 
@@ -47,6 +47,11 @@ stylesRoutes.put("/", validateJson(stylesSchema), (c) => {
       dbo.insert(asset_styles).values(rows).run();
     }
   });
-  tx();
+  try {
+    tx();
+  } catch (e) {
+    console.error("[styles] put failed:", e);
+    return jsonError(c, "STYLES_SAVE_FAILED", "Failed to save styles. Check server logs.", 500);
+  }
   return jsonData(c, { ok: true });
 });

--- a/backend/src/helpers.ts
+++ b/backend/src/helpers.ts
@@ -1,3 +1,7 @@
+export function nowUnixSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
 export function makeId(prefix: string): string {
   return `${prefix}-${crypto.randomUUID()}`;
 }

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -116,8 +116,8 @@ export const backupImportSchema = z.object({
   transactions: z.array(txImportRow).max(50_000).optional(),
   monthlyMovements: z.array(mmImportRow).max(50_000).optional(),
   monthlySnapshots: z.array(snapImportRow).max(50_000).optional(),
-  assetColors: z.record(z.string(), z.string()).optional(),
-  assetRisks: z.record(z.string(), z.string()).optional(),
+  assetColors: z.record(z.string().min(1).max(120), z.string()).optional(),
+  assetRisks: z.record(z.string().min(1).max(120), z.string()).optional(),
   preferences: prefsImportRow.optional()
 });
 

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -3,7 +3,11 @@ import { z } from "zod";
 const isoDate = z
   .string()
   .regex(/^\d{4}-\d{2}-\d{2}$/, "Expected YYYY-MM-DD")
-  .refine((v) => !isNaN(Date.parse(v)), "Invalid calendar date");
+  // Round-trip through Date to reject invalid calendar dates like "2023-02-30".
+  .refine((v) => {
+    const d = new Date(v);
+    return !isNaN(d.getTime()) && d.toISOString().slice(0, 10) === v;
+  }, "Invalid calendar date");
 
 export const loginSchema = z.object({
   email: z.string().email().max(254),
@@ -46,7 +50,7 @@ export const snapshotSchema = z.object({
 export const stylesSchema = z.object({
   styles: z
     .record(
-      z.string(),
+      z.string().min(1).max(120),
       z.object({
         colorHex: z
           .string()

--- a/backend/src/security-headers.ts
+++ b/backend/src/security-headers.ts
@@ -2,13 +2,19 @@ export const SECURITY_HEADERS: Record<string, string> = {
   "x-content-type-options": "nosniff",
   "x-frame-options": "DENY",
   "referrer-policy": "no-referrer",
-  "strict-transport-security": "max-age=63072000; includeSubDomains",
   "content-security-policy":
     "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 };
 
-export function applySecurityHeaders(headers: Headers): void {
+// Only set over HTTPS — sending HSTS on a plain-HTTP response causes the browser
+// to cache the upgrade policy and refuse HTTP entirely, breaking LAN deployments.
+const HSTS_VALUE = "max-age=63072000; includeSubDomains";
+
+export function applySecurityHeaders(headers: Headers, httpsEnabled = false): void {
   for (const [k, v] of Object.entries(SECURITY_HEADERS)) {
     headers.set(k, v);
+  }
+  if (httpsEnabled) {
+    headers.set("strict-transport-security", HSTS_VALUE);
   }
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -71,23 +71,25 @@ const server = Bun.serve({
       return api.fetch(req);
     }
 
+    const https = env.COOKIE_SECURE.toLowerCase() === "true";
     if (req.method !== "GET" && req.method !== "HEAD") {
       const headers = new Headers({ "content-type": "application/json" });
-      applySecurityHeaders(headers);
+      applySecurityHeaders(headers, https);
       return new Response(
         JSON.stringify({ error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" } }),
         { status: 405, headers }
       );
     }
 
+    const ONE_YEAR_SECONDS = 365 * 24 * 60 * 60;
     const staticFile = resolveStaticFile(env.PUBLIC_DIR, url.pathname);
     if (staticFile) {
       const headers = new Headers();
-      applySecurityHeaders(headers);
+      applySecurityHeaders(headers, https);
       // Vite hashes all filenames under /assets/ — safe to cache indefinitely.
       // Everything else (index.html) must revalidate on every request.
       if (url.pathname.startsWith("/assets/")) {
-        headers.set("cache-control", "public, max-age=31536000, immutable");
+        headers.set("cache-control", `public, max-age=${ONE_YEAR_SECONDS}, immutable`);
       } else {
         headers.set("cache-control", "no-cache");
       }
@@ -97,7 +99,7 @@ const server = Bun.serve({
     const indexFile = path.resolve(env.PUBLIC_DIR, "index.html");
     if (fs.existsSync(indexFile)) {
       const headers = new Headers();
-      applySecurityHeaders(headers);
+      applySecurityHeaders(headers, https);
       headers.set("cache-control", "no-cache");
       return new Response(Bun.file(indexFile), { headers });
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,4 @@ services:
     volumes:
       - ./data:/app/data
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 512m
+    mem_limit: 512m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,7 @@ services:
     volumes:
       - ./data:/app/data
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512m

--- a/frontend/src/features/dashboard/AssetBlocks.tsx
+++ b/frontend/src/features/dashboard/AssetBlocks.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import type { AssetStats } from "../../lib/dashboard";
-import { cycleRisk } from "../../lib/dashboard";
+import { cycleRisk, DEFAULT_COLOR } from "../../lib/dashboard";
 import { formatCurrency } from "../../lib";
 import type { RiskLevel, StylesMap } from "../../types";
 import { Card } from "@/components/ui/card";
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
 
-const DEFAULT_ASSET_COLOR = "#5de2a5"; // matches FALLBACK_PALETTE[0] in lib/dashboard.ts
+const DEFAULT_ASSET_COLOR = DEFAULT_COLOR;
 
 type Props = {
   visibleAssets: AssetStats[];

--- a/frontend/src/features/movements/MovementForm.tsx
+++ b/frontend/src/features/movements/MovementForm.tsx
@@ -10,13 +10,13 @@ import {
   SelectValue
 } from "@/components/ui/select";
 import { Field } from "@/shared/ui/Field";
-import type { MmFormValues } from "./schemas";
+import type { MmFormDefaults } from "./schemas";
 
 type Props = {
-  form: UseFormReturn<MmFormValues>;
+  form: UseFormReturn<MmFormDefaults>;
   editingId: string | null;
   isSubmitting: boolean;
-  onSubmit: (values: MmFormValues) => void;
+  onSubmit: (values: MmFormDefaults) => void;
   onCancel: () => void;
 };
 

--- a/frontend/src/features/movements/MovementsPanel.tsx
+++ b/frontend/src/features/movements/MovementsPanel.tsx
@@ -6,13 +6,13 @@ import { MovementsTable } from "./MovementsTable";
 import { useMovementsQuery } from "./useMovementsQuery";
 import { useMmMutation } from "./useMmMutation";
 import { useDeleteMovement } from "./useDeleteMovement";
-import { mmFormDefaults, type MmFormValues } from "./schemas";
+import { mmFormDefaults, mmFormSchema, type MmFormDefaults } from "./schemas";
 
 export function MovementsPanel() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const mmQuery = useMovementsQuery(true);
 
-  const form = useForm<MmFormValues>({ defaultValues: mmFormDefaults });
+  const form = useForm<MmFormDefaults>({ defaultValues: mmFormDefaults });
 
   const mmMutation = useMmMutation(editingId, () => {
     setEditingId(null);
@@ -32,7 +32,7 @@ export function MovementsPanel() {
           isSubmitting={mmMutation.isPending}
           onSubmit={(values) => {
             if (mmMutation.isPending) return;
-            mmMutation.mutate(values);
+            mmMutation.mutate(mmFormSchema.parse(values));
           }}
           onCancel={() => {
             setEditingId(null);

--- a/frontend/src/features/movements/schemas.ts
+++ b/frontend/src/features/movements/schemas.ts
@@ -9,10 +9,13 @@ export const mmFormSchema = z.object({
 
 export type MmFormValues = z.infer<typeof mmFormSchema>;
 
-export const mmFormDefaults: MmFormValues = {
+/** Default values for useForm. Number field accepts "" so the input renders
+ *  a placeholder; z.coerce.number maps "" → 0 when the form is submitted. */
+export type MmFormDefaults = Omit<MmFormValues, "amount"> & { amount: number | "" };
+
+export const mmFormDefaults: MmFormDefaults = {
   name: "",
   direction: "income",
-  // empty string renders placeholder in number input; z.coerce.number maps "" → 0 at submit
-  amount: "" as unknown as number,
+  amount: "",
   note: ""
 };

--- a/frontend/src/features/settings/useBackupActions.ts
+++ b/frontend/src/features/settings/useBackupActions.ts
@@ -16,6 +16,7 @@ function dateStamp(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
+// reason: backup payload is arbitrary JSON passed straight to JSON.stringify; shape is validated server-side
 const anySchema = apiEnvelopeSchema(z.any());
 
 export function useBackupActions() {

--- a/frontend/src/features/snapshots/SnapshotsPanel.tsx
+++ b/frontend/src/features/snapshots/SnapshotsPanel.tsx
@@ -1,8 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
-import { z } from "zod";
-import { apiEnvelopeSchema, apiFetch } from "@/lib";
-import { stylesResponse, txSchema } from "@/types";
+import { apiFetch } from "@/lib";
+import { stylesResponse, txListResponse } from "@/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { MonthlyRiskChart } from "./MonthlyRiskChart";
 import { SnapshotForm } from "./SnapshotForm";
@@ -26,7 +25,7 @@ export function SnapshotsPanel() {
     queryKey: ["transactions"],
     queryFn: async ({ signal }) =>
       apiFetch("/api/v1/transactions", { method: "GET", signal }, (raw) =>
-        apiEnvelopeSchema(z.array(txSchema)).parse(raw).data
+        txListResponse.parse(raw).data
       )
   });
   const stylesQuery = useQuery({

--- a/frontend/src/features/transactions/schemas.ts
+++ b/frontend/src/features/transactions/schemas.ts
@@ -15,8 +15,7 @@ export function tipoShowsBuyValue(tipo: string): boolean {
 }
 
 export function tipoShowsPnl(tipo: string): boolean {
-  if (TIPO_BUY_ONLY.has(tipo)) return false;
-  return true;
+  return !tipoShowsBuyValue(tipo);
 }
 
 export const txFormSchema = z.object({

--- a/frontend/src/lib/dashboard.ts
+++ b/frontend/src/lib/dashboard.ts
@@ -10,6 +10,8 @@ const FALLBACK_PALETTE = [
   "#9bd8ff"
 ];
 
+export const DEFAULT_COLOR = FALLBACK_PALETTE[0]!;
+
 export function fallbackColor(asset: string, index: number, styles: StylesMap | undefined): string {
   const fromStyle = styles?.[asset]?.colorHex;
   if (fromStyle) return fromStyle;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -46,6 +46,7 @@ export const stylesResponse = apiEnvelopeSchema(stylesMapSchema);
 export const prefsResponse = apiEnvelopeSchema(prefsSchema);
 export const txListResponse = apiEnvelopeSchema(z.array(txSchema));
 export const mmListResponse = apiEnvelopeSchema(z.array(mmSchema));
+export const snapListResponse = apiEnvelopeSchema(z.array(snapSchema));
 
 export type Transaction = z.infer<typeof txSchema>;
 export type Movement = z.infer<typeof mmSchema>;


### PR DESCRIPTION
## Summary

- **Security**: HSTS sent only when `COOKIE_SECURE=true`; sending it over plain HTTP caused browsers to cache an upgrade policy that broke LAN/HTTP deployments
- **Security**: XLSX/JSON import — JSON parse errors now return `INVALID_JSON` instead of the misleading `MISSING_FILE` code
- **Bugs**: `purge` and `PUT /assets/styles` routes now wrap `tx()` in try/catch; unhandled DB exceptions were surfacing as raw 500s
- **Bugs**: backup import — `derived_type` now capped at 40 chars (schema limit); invalid movement `direction` rows are skipped instead of silently reclassified as `"income"`; ISO-date validation strengthened with round-trip check to reject non-existent dates like `"2023-02-30"`
- **Bugs**: `stylesSchema` record keys now bounded to `min(1)/max(120)` characters
- **Performance**: `sessionGuard` and `GET /auth/session` now use a single JOIN (session + user) instead of two sequential SELECTs — one DB round-trip eliminated per authenticated API call
- **Quality**: `nowUnixSeconds()` helper extracted to remove three duplicated `Math.floor(Date.now()/1000)` expressions; `ONE_YEAR_SECONDS` named constant replaces magic `31536000`; `MmFormDefaults` type added (removes `"" as unknown as number` type lie); `snapListResponse` exported from `types.ts`; `DEFAULT_COLOR` exported from `dashboard.ts` to eliminate duplicate hex literal; `SnapshotsPanel` uses shared `txListResponse` instead of inline schema; `tipoShowsPnl` simplified to `!tipoShowsBuyValue`
- **Infra**: `Dockerfile` frontend stage now uses `--frozen-lockfile`; `docker-compose.yml` adds memory limit (512 m); `.gitignore` covers `*.bak`

## Deferred findings

Nuovi deferred findings: https://github.com/LiukScot/money/issues/100

I seguenti finding già tracciati in issue aperti sono stati scartati per dedup:
- `xforwardedfor-ratelimit-bypass` — #86
- `session-guard-two-selects` — #86 (**SHIPPED in questo PR**)
- `compose-no-resource-limits` — #93 (**SHIPPED in questo PR**)
- `drizzle-kit-esbuild-cve` — #86
- `exceljs-uuid-cve` — #86
- `no-code-splitting` — #86
- `xlsx-no-magic-byte-check` — #93

## Sub-analyst reports

- **Security**: HSTS-over-HTTP bug, COOKIE_SECURE default reasoning, X-Forwarded-For rate-limit bypass, XLSX magic-byte gap, user-cli plaintext password
- **Quality**: `z.any()` without reason, `MmFormDefaults` type lie, duplicate schema constructions, `nowUnixSeconds` triplicated, `DEFAULT_COLOR` duplicate, AccountMenu inaccessible dropdown
- **Bugs**: `derived_type` unbounded, unguarded `tx()` in purge and styles, invalid direction silent reclassification, invalid calendar dates accepted
- **Tests**: XLSX multipart path untested, expired session path untested, `mmFormSchema` edge cases, E2E gaps for movements/snapshots/change-password/danger-zone
- **Deps**: esbuild CVE via drizzle-kit (devDep, no fix available), uuid CVE via exceljs (no upgrade path), Dockerfile frozen-lockfile missing, `*.bak` not gitignored
- **Performance**: N+1 on every authenticated request (sessionGuard + GET /session), DEFAULT_LIMIT=1000 fetched unbounded, no code splitting in router

---
Generated automatically by Codebase Analyst — 2026-06-13