### PR TITLE
fix: accessible AccountMenu, safer user-cli password, document session wipe

### DIFF
--- a/backend/src/api/auth.ts
+++ b/backend/src/api/auth.ts
@@ -91,6 +91,10 @@ authRoutes.post("/login", async (c, next) => {
       console.error("[auth] rehash write failed (login still succeeds):", e);
     }
   }
+  // Intentional: drop every prior session on login. This is a single-user
+  // app, so there are no legitimate concurrent sessions to preserve, and
+  // wiping them avoids leaving zombie sessions behind (e.g. an old device
+  // that never logged out). Not a bug.
   getDrizzle(db).delete(user_sessions).where(eq(user_sessions.user_id, user.id)).run();
   const { sid } = createSession(db, user.id, user.email, env.SESSION_TTL_SECONDS);
   setSessionCookie(c, env, sid);

--- a/backend/src/scripts.test.ts
+++ b/backend/src/scripts.test.ts
@@ -134,6 +134,41 @@ describe("user-cli.ts", () => {
     );
     expect(result.exitCode).not.toBe(0);
   });
+
+  test("create reads password from CLI_PASSWORD env", async () => {
+    const dir = mkTmpDir("mymoney-user-cli-env-");
+    const dbPath = path.join(dir, "test.sqlite");
+    await runScript("migrate.ts", [`--db=${dbPath}`]);
+
+    const create = await runScript(
+      "user-cli.ts",
+      ["create", "--email=env@example.com", "--name=Env"],
+      { DB_PATH: dbPath, CLI_PASSWORD: "EnvPassword123!" }
+    );
+    expect(create.exitCode).toBe(0);
+    expect(create.stdout).toContain("User created");
+
+    const db = new Database(dbPath, { readonly: true });
+    const row = db
+      .query(`SELECT password_hash FROM users WHERE email = ?`)
+      .get("env@example.com") as { password_hash: string };
+    db.close();
+    expect(row.password_hash.length).toBeGreaterThan(0);
+  });
+
+  test("create fails with no password and no TTY", async () => {
+    const dir = mkTmpDir("mymoney-user-cli-nopw-");
+    const dbPath = path.join(dir, "test.sqlite");
+    await runScript("migrate.ts", [`--db=${dbPath}`]);
+
+    const create = await runScript(
+      "user-cli.ts",
+      ["create", "--email=nopw@example.com"],
+      { DB_PATH: dbPath }
+    );
+    expect(create.exitCode).not.toBe(0);
+    expect(create.stderr).toContain("No password provided");
+  });
 });
 
 describe("backup-db.ts + restore-db.ts round-trip", () => {

--- a/backend/src/user-cli.ts
+++ b/backend/src/user-cli.ts
@@ -74,12 +74,18 @@ function promptHidden(label: string): Promise<string> {
         value += ch;
       }
     };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
     const cleanup = () => {
       stdin.setRawMode(false);
       stdin.pause();
       stdin.removeListener("data", onData);
+      stdin.removeListener("error", onError);
     };
     stdin.on("data", onData);
+    stdin.on("error", onError);
   });
 }
 

--- a/backend/src/user-cli.ts
+++ b/backend/src/user-cli.ts
@@ -19,6 +19,70 @@ function required(name: string): string {
   return v;
 }
 
+/**
+ * Resolve the password without forcing it onto the command line, where it
+ * would leak into shell history and the process list (`ps`). Precedence:
+ * CLI_PASSWORD env -> --password arg (kept for backward compat) -> an
+ * interactive prompt with terminal echo disabled. Never logged.
+ */
+async function resolvePassword(): Promise<string> {
+  const fromEnv = process.env.CLI_PASSWORD;
+  if (fromEnv) return fromEnv;
+
+  const fromArg = arg("password");
+  if (fromArg) return fromArg;
+
+  if (!process.stdin.isTTY) {
+    throw new Error(
+      "No password provided. Set CLI_PASSWORD, pass --password=..., or run interactively."
+    );
+  }
+  return promptHidden("Password: ");
+}
+
+function promptHidden(label: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const stdin = process.stdin;
+    const ENTER = ["\n", "\r"];
+    const EOF = "\u0004"; // Ctrl-D
+    const SIGINT = "\u0003"; // Ctrl-C
+    const BACKSPACE = ["\u007f", "\b"]; // DEL, backspace
+    process.stdout.write(label);
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding("utf8");
+
+    let value = "";
+    const onData = (chunk: string) => {
+      for (const ch of chunk) {
+        if (ENTER.includes(ch) || ch === EOF) {
+          cleanup();
+          process.stdout.write("\n");
+          resolve(value);
+          return;
+        }
+        if (ch === SIGINT) {
+          cleanup();
+          process.stdout.write("\n");
+          reject(new Error("Aborted"));
+          return;
+        }
+        if (BACKSPACE.includes(ch)) {
+          value = value.slice(0, -1);
+          continue;
+        }
+        value += ch;
+      }
+    };
+    const cleanup = () => {
+      stdin.setRawMode(false);
+      stdin.pause();
+      stdin.removeListener("data", onData);
+    };
+    stdin.on("data", onData);
+  });
+}
+
 async function main() {
   const db = openDb(dbPath);
   runMigrations(db);
@@ -44,7 +108,7 @@ async function main() {
 
   if (cmd === "create") {
     const email = required("email").trim().toLowerCase();
-    const password = required("password");
+    const password = await resolvePassword();
     const name = arg("name") ?? null;
     const hash = await Bun.password.hash(password, { algorithm: "argon2id" });
     dbo.insert(users).values({ email, password_hash: hash, name }).run();
@@ -55,7 +119,7 @@ async function main() {
 
   if (cmd === "reset-password") {
     const email = required("email").trim().toLowerCase();
-    const password = required("password");
+    const password = await resolvePassword();
     const hash = await Bun.password.hash(password, { algorithm: "argon2id" });
     const result = dbo
       .update(users)

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -392,8 +392,8 @@ describe("Logout flow", () => {
     testState.authenticated = true;
     renderApp();
     await screen.findByRole("heading", { name: "Dashboard" });
-    await user.click(screen.getByText("Account"));
-    await user.click(screen.getByRole("button", { name: /log out/i }));
+    await user.click(screen.getByRole("button", { name: "Account" }));
+    await user.click(await screen.findByRole("menuitem", { name: /log out/i }));
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "money" })).toBeInTheDocument();
     });

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,91 @@
+import * as React from "react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 8,
+  align = "end",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        align={align}
+        className={cn(
+          "z-50 min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-lg data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item>) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-hidden select-none transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label>) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+}

--- a/frontend/src/features/auth/AccountMenu.test.tsx
+++ b/frontend/src/features/auth/AccountMenu.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const logoutMutate = vi.fn();
+const changePasswordMutate = vi.fn();
+
+vi.mock("./useLogoutMutation", () => ({
+  useLogoutMutation: () => ({ mutate: logoutMutate, isPending: false })
+}));
+
+vi.mock("./useChangePasswordMutation", () => ({
+  useChangePasswordMutation: () => ({
+    mutate: changePasswordMutate,
+    isPending: false,
+    error: null
+  })
+}));
+
+import { AccountMenu } from "./AccountMenu";
+
+describe("AccountMenu", () => {
+  beforeEach(() => {
+    logoutMutate.mockClear();
+    changePasswordMutate.mockClear();
+  });
+
+  test("trigger is a real button reachable by keyboard", async () => {
+    const user = userEvent.setup();
+    render(<AccountMenu />);
+
+    const trigger = screen.getByRole("button", { name: /account/i });
+    await user.tab();
+    expect(trigger).toHaveFocus();
+  });
+
+  test("opens menu with keyboard and exposes menu items", async () => {
+    const user = userEvent.setup();
+    render(<AccountMenu />);
+
+    await user.tab();
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(screen.getByRole("menu")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("menuitem", { name: /change password/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /log out/i })).toBeInTheDocument();
+  });
+
+  test("Escape closes the menu", async () => {
+    const user = userEvent.setup();
+    render(<AccountMenu />);
+
+    await user.tab();
+    await user.keyboard("{Enter}");
+    await waitFor(() => expect(screen.getByRole("menu")).toBeInTheDocument());
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(screen.queryByRole("menu")).not.toBeInTheDocument());
+  });
+
+  test("Log out item triggers logout", async () => {
+    const user = userEvent.setup();
+    render(<AccountMenu />);
+
+    await user.click(screen.getByRole("button", { name: /account/i }));
+    await user.click(screen.getByRole("menuitem", { name: /log out/i }));
+
+    expect(logoutMutate).toHaveBeenCalledTimes(1);
+  });
+
+  test("Change password item reveals the form outside the menu", async () => {
+    const user = userEvent.setup();
+    render(<AccountMenu />);
+
+    await user.click(screen.getByRole("button", { name: /account/i }));
+    await user.click(screen.getByRole("menuitem", { name: /change password/i }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/current password/i)).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText(/new password/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/auth/AccountMenu.tsx
+++ b/frontend/src/features/auth/AccountMenu.tsx
@@ -4,28 +4,51 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Field } from "@/shared/ui/Field";
 import { changePasswordSchema, type ChangePasswordValues } from "./schemas";
 import { useChangePasswordMutation } from "./useChangePasswordMutation";
 import { useLogoutMutation } from "./useLogoutMutation";
 
 export function AccountMenu() {
-  const [open, setOpen] = useState(false);
+  const [changePasswordOpen, setChangePasswordOpen] = useState(false);
   const form = useForm<ChangePasswordValues>({ resolver: zodResolver(changePasswordSchema) });
-  const changePasswordMutation = useChangePasswordMutation(() => form.reset());
+  const changePasswordMutation = useChangePasswordMutation(() => {
+    form.reset();
+    setChangePasswordOpen(false);
+  });
   const logoutMutation = useLogoutMutation();
 
   return (
     <div className="relative">
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={() => setOpen((o) => !o)}
-        aria-expanded={open}
-      >
-        Account
-      </Button>
-      {open && (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm">
+            Account
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-48">
+          <DropdownMenuItem
+            onSelect={() => setChangePasswordOpen((o) => !o)}
+          >
+            Change password
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            disabled={logoutMutation.isPending}
+            onSelect={() => logoutMutation.mutate()}
+          >
+            Log out
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {changePasswordOpen && (
         <div className="absolute right-0 top-full mt-2 z-20 w-80 rounded-lg border border-border bg-popover p-4 shadow-lg">
           <form
             className="grid gap-3"
@@ -49,16 +72,6 @@ export function AccountMenu() {
               </Alert>
             )}
           </form>
-          <div className="mt-3 pt-3 border-t border-border">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => logoutMutation.mutate()}
-              disabled={logoutMutation.isPending}
-            >
-              Log out
-            </Button>
-          </div>
         </div>
       )}
     </div>

--- a/frontend/src/features/auth/AccountMenu.tsx
+++ b/frontend/src/features/auth/AccountMenu.tsx
@@ -34,9 +34,7 @@ export function AccountMenu() {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent className="w-48">
-          <DropdownMenuItem
-            onSelect={() => setChangePasswordOpen((o) => !o)}
-          >
+          <DropdownMenuItem onSelect={() => setChangePasswordOpen(true)}>
             Change password
           </DropdownMenuItem>
           <DropdownMenuSeparator />

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -26,8 +26,8 @@ test.describe("auth flows", () => {
 
   test("logout returns to login screen", async ({ page }) => {
     await loginUi(page);
-    await page.getByText("Account").click();
-    await page.getByRole("button", { name: /log out/i }).click();
+    await page.getByRole("button", { name: "Account" }).click();
+    await page.getByRole("menuitem", { name: /log out/i }).click();
     await expect(page.getByRole("heading", { name: "money" })).toBeVisible();
     await expect(page.getByLabel("Email")).toBeVisible();
   });


### PR DESCRIPTION
Part of #100

Implements three approved deferred findings.

## 1. AccountMenu not accessible (MEDIUM)
`frontend/src/features/auth/AccountMenu.tsx` used a custom `div`+`onClick`
popover with no keyboard support and no menu semantics (AGENTS.md §15).
Replaced with the shadcn Radix `DropdownMenu`:

- Added `frontend/src/components/ui/dropdown-menu.tsx` (shadcn-style
  wrapper over `radix-ui`, matching the repo's `data-slot` + `cn`
  pattern used by `select.tsx` / `alert-dialog.tsx`). The repo did
  **not** previously have this component.
- Trigger is a real `<Button>` (via `asChild`); Tab reaches it, Enter
  opens, Escape closes, arrow keys move between items, proper `menu` /
  `menuitem` roles.
- The change-password form stays **outside** the dropdown (toggled by a
  menu item), so its labelled inputs are untouched and the menu is not
  trapped by an embedded form.

## 2. user-cli password as CLI arg (MEDIUM)
`backend/src/user-cli.ts` required `--password=...`, leaking the secret
into shell history and the process list (`ps`). Added `resolvePassword`
with precedence: `CLI_PASSWORD` env → `--password` arg (kept for
backward compat) → interactive stdin prompt with terminal echo disabled.
Non-TTY callers without a password fail with a clear message instead of
hanging. The password is never logged.

**Non-breaking** — existing automation that uses `--password` keeps
working (see callers noted in the PR discussion).

## 3. login wipes all sessions (LOW)
`backend/src/api/auth.ts` deletes all of a user's sessions on login.
Decision: keep this behavior (single-user app, avoids zombie sessions).
Added a code comment documenting it is intentional, not a bug.

## Tests
- `backend/src/scripts.test.ts`: `CLI_PASSWORD` env path + non-TTY
  no-password failure.
- `frontend/src/features/auth/AccountMenu.test.tsx`: keyboard reachable
  trigger, open via Enter, Escape closes, logout fires, change-password
  reveals the form.
- Updated `frontend/src/App.test.tsx` logout flow for the new
  `menuitem` semantics.

## Verification
- backend typecheck: clean
- backend tests: 141 pass
- frontend build (tsc -b + vite): clean
- frontend tests: 58 pass
- lint: only pre-existing errors in `router.tsx` / `DashboardPanel.tsx`
  (untouched by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)