### PR TITLE
fix(frontend): clear pre-existing ESLint problems (react-refresh + exhaustive-deps)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -11,7 +11,7 @@ vi.mock("react-chartjs-2", () => ({
   Doughnut: () => null
 }));
 
-import { createAppRouter } from "./router.tsx";
+import { createAppRouter } from "./router-config.ts";
 import { resetTestState, testState } from "./test-msw.ts";
 
 function renderApp() {

--- a/frontend/src/features/dashboard/DashboardPanel.tsx
+++ b/frontend/src/features/dashboard/DashboardPanel.tsx
@@ -87,9 +87,9 @@ export function DashboardPanel() {
     }
   });
 
-  const transactions: Transaction[] = txQuery.data ?? [];
-  const movements: Movement[] = mmQuery.data ?? [];
-  const stylesMap: StylesMap = stylesQuery.data ?? {};
+  const transactions: Transaction[] = useMemo(() => txQuery.data ?? [], [txQuery.data]);
+  const movements: Movement[] = useMemo(() => mmQuery.data ?? [], [mmQuery.data]);
+  const stylesMap: StylesMap = useMemo(() => stylesQuery.data ?? {}, [stylesQuery.data]);
   const prefs: Preferences = prefsQuery.data ?? { showZeroAssets: false, updatedAt: null };
 
   const allStats = useMemo(() => computePerAsset(transactions, stylesMap), [transactions, stylesMap]);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "@tanstack/react-router";
-import { router } from "./router";
+import { router } from "./router-config";
 import { Toaster } from "@/components/ui/sonner";
 import "./styles.css";
 

--- a/frontend/src/router-config.ts
+++ b/frontend/src/router-config.ts
@@ -1,0 +1,81 @@
+import {
+  createRootRoute,
+  createRoute,
+  createRouter,
+  redirect
+} from "@tanstack/react-router";
+import { DashboardPanel } from "@/features/dashboard/DashboardPanel";
+import { MovementsPanel } from "@/features/movements/MovementsPanel";
+import { SettingsPanel } from "@/features/settings/SettingsPanel";
+import { SnapshotsPanel } from "@/features/snapshots/SnapshotsPanel";
+import { TransactionsPanel } from "@/features/transactions/TransactionsPanel";
+import { NotFound, RootShell } from "./router";
+
+const rootRoute = createRootRoute({
+  component: RootShell
+});
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  beforeLoad: () => {
+    throw redirect({ to: "/dashboard" });
+  }
+});
+
+const dashboardRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/dashboard",
+  component: DashboardPanel
+});
+
+const transactionsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/transactions",
+  component: TransactionsPanel
+});
+
+const movementsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/movements",
+  component: MovementsPanel
+});
+
+const snapshotsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/snapshots",
+  component: SnapshotsPanel
+});
+
+const settingsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/settings",
+  component: SettingsPanel
+});
+
+export const routeTree = rootRoute.addChildren([
+  indexRoute,
+  dashboardRoute,
+  transactionsRoute,
+  movementsRoute,
+  snapshotsRoute,
+  settingsRoute
+]);
+
+export function createAppRouter(
+  opts: Partial<Parameters<typeof createRouter>[0]> = {}
+) {
+  return createRouter({
+    routeTree,
+    defaultNotFoundComponent: NotFound,
+    ...opts
+  });
+}
+
+export const router = createAppRouter();
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,13 +1,10 @@
 import { lazy, Suspense } from "react";
-import {
-  createRootRoute,
-  createRoute,
-  createRouter,
-  Link,
-  Outlet,
-  redirect
-} from "@tanstack/react-router";
+import { Link, Outlet } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
+import { AccountMenu } from "@/features/auth/AccountMenu";
+import { LoginScreen } from "@/features/auth/LoginScreen";
+import { useAuthStore } from "@/shared/auth/authStore";
+import { useSessionSync } from "@/shared/auth/useSessionSync";
 
 const RouterDevtools = import.meta.env.DEV
   ? lazy(() =>
@@ -16,15 +13,6 @@ const RouterDevtools = import.meta.env.DEV
       }))
     )
   : () => null;
-import { AccountMenu } from "@/features/auth/AccountMenu";
-import { LoginScreen } from "@/features/auth/LoginScreen";
-import { DashboardPanel } from "@/features/dashboard/DashboardPanel";
-import { MovementsPanel } from "@/features/movements/MovementsPanel";
-import { SettingsPanel } from "@/features/settings/SettingsPanel";
-import { SnapshotsPanel } from "@/features/snapshots/SnapshotsPanel";
-import { TransactionsPanel } from "@/features/transactions/TransactionsPanel";
-import { useAuthStore } from "@/shared/auth/authStore";
-import { useSessionSync } from "@/shared/auth/useSessionSync";
 
 const navItems = [
   { to: "/dashboard", label: "dashboard" },
@@ -50,7 +38,7 @@ function NavLink({ to, label }: { to: string; label: string }) {
   );
 }
 
-function RootShell() {
+export function RootShell() {
   const user = useAuthStore((s) => s.user);
   const sessionQuery = useSessionSync();
 
@@ -85,82 +73,15 @@ function RootShell() {
   );
 }
 
-const rootRoute = createRootRoute({
-  component: RootShell
-});
-
-const indexRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: "/",
-  beforeLoad: () => {
-    throw redirect({ to: "/dashboard" });
-  }
-});
-
-const dashboardRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: "/dashboard",
-  component: DashboardPanel
-});
-
-const transactionsRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: "/transactions",
-  component: TransactionsPanel
-});
-
-const movementsRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: "/movements",
-  component: MovementsPanel
-});
-
-const snapshotsRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: "/snapshots",
-  component: SnapshotsPanel
-});
-
-const settingsRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: "/settings",
-  component: SettingsPanel
-});
-
-export const routeTree = rootRoute.addChildren([
-  indexRoute,
-  dashboardRoute,
-  transactionsRoute,
-  movementsRoute,
-  snapshotsRoute,
-  settingsRoute
-]);
-
-const NotFound = () => (
-  <main className="min-h-screen grid place-items-center p-6">
-    <div className="text-center grid gap-2">
-      <h2 className="text-2xl font-semibold">Page not found</h2>
-      <Link to="/dashboard" className="text-sm text-muted-foreground underline">
-        Back to dashboard
-      </Link>
-    </div>
-  </main>
-);
-
-export function createAppRouter(
-  opts: Partial<Parameters<typeof createRouter>[0]> = {}
-) {
-  return createRouter({
-    routeTree,
-    defaultNotFoundComponent: NotFound,
-    ...opts
-  });
-}
-
-export const router = createAppRouter();
-
-declare module "@tanstack/react-router" {
-  interface Register {
-    router: typeof router;
-  }
+export function NotFound() {
+  return (
+    <main className="min-h-screen grid place-items-center p-6">
+      <div className="text-center grid gap-2">
+        <h2 className="text-2xl font-semibold">Page not found</h2>
+        <Link to="/dashboard" className="text-sm text-muted-foreground underline">
+          Back to dashboard
+        </Link>
+      </div>
+    </main>
+  );
 }


### PR DESCRIPTION
## What

Clears the 9 pre-existing ESLint problems standing on `main` (not from a
recent PR). `npm --prefix frontend run lint` now reports **0 errors, 0
warnings**.

## Changes

### 1. `react-refresh/only-export-components` (4 errors) — router export split

`router.tsx` mixed component definitions (`RootShell`, `NavLink`,
`NotFound`) with non-component exports (`routeTree`, `createAppRouter`,
`router`). Fast Refresh only works when a module exports components only,
so the rule fired.

- `router.tsx` is now **component-only**: exports `RootShell` and
  `NotFound` (`NavLink` and `RouterDevtools` stay file-local). `NotFound`
  was converted from an arrow const to a named `function` to match the
  sibling components in the same file.
- New sibling **`router-config.ts`** holds the route assembly:
  the `createRoute`/`createRootRoute` definitions, `routeTree`,
  `createAppRouter`, `router`, and the `declare module` augmentation. No
  JSX, so no Fast Refresh concern.
- Importers updated: `main.tsx` (`./router` → `./router-config`) and
  `App.test.tsx` (`./router.tsx` → `./router-config.ts`).

### 2. `react-hooks/exhaustive-deps` (5 warnings) — stabilize dashboard deps

In `DashboardPanel.tsx`, `transactions`, `movements` and `stylesMap` were
`query.data ?? fallback` expressions assigned to plain consts. The
fallback (`[]` / `{}`) creates a new identity every render, so every
`useMemo`/`useCallback` depending on them recomputed each render. Each is
now wrapped in its own `useMemo` keyed on the underlying `query.data`, so
the value only changes when the data actually changes. (`prefs` was left
as-is — only its primitive `prefs.showZeroAssets` is used as a dep, which
is stable by value and was never flagged.)

## Verify

- `npm --prefix frontend run lint` → 0 problems
- `npm --prefix frontend run build` → passes (`tsc -b` + vite)
- `npm --prefix frontend run test` → 8 files, 58 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)