### PR TITLE
fix: codebase analysis findings 2026-06-20

### DIFF
--- a/backend/drizzle/0001_drop_redundant_index.sql
+++ b/backend/drizzle/0001_drop_redundant_index.sql
@@ -1,0 +1,1 @@
+DROP INDEX `idx_asset_style_user`;

--- a/backend/drizzle/meta/0001_snapshot.json
+++ b/backend/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,625 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6d8bdebe-92c4-4a0a-a5bc-2bf5728006ae",
+  "prevId": "4654bd79-f09e-4218-8f58-28a23cd0c4ce",
+  "tables": {
+    "asset_styles": {
+      "name": "asset_styles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset": {
+          "name": "asset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_level": {
+          "name": "risk_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "asset_styles_user_asset_unique": {
+          "name": "asset_styles_user_asset_unique",
+          "columns": [
+            "user_id",
+            "asset"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "asset_styles_user_id_users_id_fk": {
+          "name": "asset_styles_user_id_users_id_fk",
+          "tableFrom": "asset_styles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "monthly_movements": {
+      "name": "monthly_movements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_mm_user": {
+          "name": "idx_mm_user",
+          "columns": [
+            "user_id",
+            "direction"
+          ],
+          "isUnique": false
+        },
+        "idx_mm_user_name": {
+          "name": "idx_mm_user_name",
+          "columns": [
+            "user_id",
+            "name",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "monthly_movements_user_id_users_id_fk": {
+          "name": "monthly_movements_user_id_users_id_fk",
+          "tableFrom": "monthly_movements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "monthly_snapshots": {
+      "name": "monthly_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "low_risk": {
+          "name": "low_risk",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "medium_risk": {
+          "name": "medium_risk",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "high_risk": {
+          "name": "high_risk",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "liquid": {
+          "name": "liquid",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_snap_user_date": {
+          "name": "idx_snap_user_date",
+          "columns": [
+            "user_id",
+            "\"snapshot_date\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "monthly_snapshots_user_id_users_id_fk": {
+          "name": "monthly_snapshots_user_id_users_id_fk",
+          "tableFrom": "monthly_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transactions": {
+      "name": "transactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tx_date": {
+          "name": "tx_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset": {
+          "name": "asset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tipo": {
+          "name": "tipo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "derived_type": {
+          "name": "derived_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "buy_value": {
+          "name": "buy_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pnl": {
+          "name": "pnl",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_tx_user_date": {
+          "name": "idx_tx_user_date",
+          "columns": [
+            "user_id",
+            "\"tx_date\" DESC"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_preferences": {
+      "name": "user_preferences",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "show_zero_assets": {
+          "name": "show_zero_assets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_sessions": {
+      "name": "user_sessions",
+      "columns": {
+        "sid": {
+          "name": "sid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_user_sessions_user": {
+          "name": "idx_user_sessions_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_sessions_expires_at": {
+          "name": "idx_user_sessions_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_sessions_user_id_users_id_fk": {
+          "name": "user_sessions_user_id_users_id_fk",
+          "tableFrom": "user_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "idx_snap_user_date": {
+        "columns": {
+          "\"snapshot_date\" DESC": {
+            "isExpression": true
+          }
+        }
+      },
+      "idx_tx_user_date": {
+        "columns": {
+          "\"tx_date\" DESC": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1779715185921,
       "tag": "0000_init",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1781917887241,
+      "tag": "0001_drop_redundant_index",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,7 +11,7 @@
         "bcryptjs": "^3.0.3",
         "drizzle-orm": "^0.45.2",
         "exceljs": "^4.4.0",
-        "hono": "^4.12.23",
+        "hono": "^4.12.26",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -1221,9 +1221,9 @@
       "license": "ISC"
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,7 @@
     "bcryptjs": "^3.0.3",
     "drizzle-orm": "^0.45.2",
     "exceljs": "^4.4.0",
-    "hono": "^4.12.23",
+    "hono": "^4.12.26",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/backend/src/api/auth.ts
+++ b/backend/src/api/auth.ts
@@ -95,9 +95,13 @@ authRoutes.post("/login", async (c, next) => {
   // app, so there are no legitimate concurrent sessions to preserve, and
   // wiping them avoids leaving zombie sessions behind (e.g. an old device
   // that never logged out). Not a bug.
-  getDrizzle(db).delete(user_sessions).where(eq(user_sessions.user_id, user.id)).run();
-  const { sid } = createSession(db, user.id, user.email, env.SESSION_TTL_SECONDS);
-  setSessionCookie(c, env, sid);
+  let newSid: string;
+  db.transaction(() => {
+    getDrizzle(db).delete(user_sessions).where(eq(user_sessions.user_id, user.id)).run();
+    const sess = createSession(db, user.id, user.email, env.SESSION_TTL_SECONDS);
+    newSid = sess.sid;
+  })();
+  setSessionCookie(c, env, newSid!);
   return jsonData(c, { email: user.email, name: user.name ?? null });
 });
 

--- a/backend/src/api/auth.ts
+++ b/backend/src/api/auth.ts
@@ -95,13 +95,11 @@ authRoutes.post("/login", async (c, next) => {
   // app, so there are no legitimate concurrent sessions to preserve, and
   // wiping them avoids leaving zombie sessions behind (e.g. an old device
   // that never logged out). Not a bug.
-  let newSid: string;
-  db.transaction(() => {
+  const { sid } = db.transaction(() => {
     getDrizzle(db).delete(user_sessions).where(eq(user_sessions.user_id, user.id)).run();
-    const sess = createSession(db, user.id, user.email, env.SESSION_TTL_SECONDS);
-    newSid = sess.sid;
+    return createSession(db, user.id, user.email, env.SESSION_TTL_SECONDS);
   })();
-  setSessionCookie(c, env, newSid!);
+  setSessionCookie(c, env, sid);
   return jsonData(c, { email: user.email, name: user.name ?? null });
 });
 

--- a/backend/src/api/backup.ts
+++ b/backend/src/api/backup.ts
@@ -29,7 +29,11 @@ backupRoutes.post("/json/import", validateJson(backupImportSchema), (c) => {
       assetColors: body.assetColors ?? {},
       assetRisks: body.assetRisks ?? {},
       preferences: {
-        showZeroAssets: Boolean((body.preferences ?? {}).showZeroAssets ?? false)
+        showZeroAssets: (() => {
+          const raw = (body.preferences ?? {}).showZeroAssets;
+          const s = String(raw ?? "").trim().toLowerCase();
+          return raw === true || raw === 1 || s === "true" || s === "1";
+        })()
       },
       replaceStyles: true,
       replacePrefs: true
@@ -152,6 +156,10 @@ backupRoutes.post("/xlsx/import", async (c) => {
       return jsonError(c, "FILE_TOO_LARGE", "File exceeds 10 MB limit", 400);
     }
     const arr = await file.arrayBuffer();
+    const magic = new Uint8Array(arr, 0, 4);
+    if (magic[0] !== 0x50 || magic[1] !== 0x4B || magic[2] !== 0x03 || magic[3] !== 0x04) {
+      return jsonError(c, "INVALID_FILE", "Could not parse file as XLSX", 400);
+    }
     try {
       await wb.xlsx.load(arr);
     } catch {
@@ -173,9 +181,16 @@ backupRoutes.post("/xlsx/import", async (c) => {
         400
       );
     }
+    // base64 overhead is ~1.33x, so cap the encoded string before allocating the buffer
+    if (payload.base64.length > MAX_XLSX_BYTES * 1.4) {
+      return jsonError(c, "FILE_TOO_LARGE", "File exceeds 10 MB limit", 400);
+    }
     const rawBytes = Buffer.from(payload.base64, "base64");
     if (rawBytes.byteLength > MAX_XLSX_BYTES) {
       return jsonError(c, "FILE_TOO_LARGE", "File exceeds 10 MB limit", 400);
+    }
+    if (rawBytes[0] !== 0x50 || rawBytes[1] !== 0x4B || rawBytes[2] !== 0x03 || rawBytes[3] !== 0x04) {
+      return jsonError(c, "INVALID_FILE", "Could not parse file as XLSX", 400);
     }
     try {
       await wb.xlsx.load(rawBytes.buffer.slice(rawBytes.byteOffset, rawBytes.byteOffset + rawBytes.byteLength));
@@ -193,6 +208,15 @@ backupRoutes.post("/xlsx/import", async (c) => {
   const transactions = sheetToObjects(txSheet);
   const monthlyMovements = sheetToObjects(mmSheet);
   const monthlySnapshots = sheetToObjects(snapSheet);
+
+  const MAX_IMPORT_ROWS = 50_000;
+  if (
+    transactions.length > MAX_IMPORT_ROWS ||
+    monthlyMovements.length > MAX_IMPORT_ROWS ||
+    monthlySnapshots.length > MAX_IMPORT_ROWS
+  ) {
+    return jsonError(c, "FILE_TOO_LARGE", "Import exceeds row limit (50 000 per sheet)", 400);
+  }
   const styleRows = sheetToObjects(styleSheet);
   const prefRows = sheetToObjects(prefSheet);
 

--- a/backend/src/api/backup.ts
+++ b/backend/src/api/backup.ts
@@ -7,6 +7,8 @@ import type { AppEnv } from "./types.ts";
 import { jsonData, jsonError, validateJson } from "./responses.ts";
 
 const MAX_XLSX_BYTES = 10 * 1024 * 1024;
+// base64 inflation is exactly ceil(n * 4/3); +4 accounts for padding
+const MAX_XLSX_BASE64_LENGTH = Math.ceil(MAX_XLSX_BYTES * 4 / 3) + 4;
 
 export const backupRoutes = new Hono<AppEnv>();
 
@@ -156,6 +158,9 @@ backupRoutes.post("/xlsx/import", async (c) => {
       return jsonError(c, "FILE_TOO_LARGE", "File exceeds 10 MB limit", 400);
     }
     const arr = await file.arrayBuffer();
+    if (arr.byteLength < 4) {
+      return jsonError(c, "INVALID_FILE", "Could not parse file as XLSX", 400);
+    }
     const magic = new Uint8Array(arr, 0, 4);
     if (magic[0] !== 0x50 || magic[1] !== 0x4B || magic[2] !== 0x03 || magic[3] !== 0x04) {
       return jsonError(c, "INVALID_FILE", "Could not parse file as XLSX", 400);
@@ -181,8 +186,7 @@ backupRoutes.post("/xlsx/import", async (c) => {
         400
       );
     }
-    // base64 overhead is ~1.33x, so cap the encoded string before allocating the buffer
-    if (payload.base64.length > MAX_XLSX_BYTES * 1.4) {
+    if (payload.base64.length > MAX_XLSX_BASE64_LENGTH) {
       return jsonError(c, "FILE_TOO_LARGE", "File exceeds 10 MB limit", 400);
     }
     const rawBytes = Buffer.from(payload.base64, "base64");

--- a/backend/src/api/middleware.ts
+++ b/backend/src/api/middleware.ts
@@ -11,7 +11,7 @@ import { jsonError } from "./responses.ts";
 export const securityHeaders: MiddlewareHandler<AppEnv> = async (c, next) => {
   await next();
   const env = c.get("env");
-  applySecurityHeaders(c.res.headers, env.COOKIE_SECURE.toLowerCase() === "true");
+  applySecurityHeaders(c.res.headers, env.COOKIE_SECURE);
 };
 
 export function originGuard(allowedOriginsCsv: string): MiddlewareHandler<AppEnv> {
@@ -82,7 +82,11 @@ export const sessionGuard: MiddlewareHandler<AppEnv> = async (c, next) => {
     return jsonError(c, "UNAUTHORIZED", "Authentication required", 401);
   }
   if (Number(row.expires_at) <= now) {
-    dbo.delete(user_sessions).where(eq(user_sessions.sid, sid)).run();
+    try {
+      dbo.delete(user_sessions).where(eq(user_sessions.sid, sid)).run();
+    } catch (e) {
+      console.error("[sessionGuard] failed to delete expired session:", e);
+    }
     return jsonError(c, "UNAUTHORIZED", "Authentication required", 401);
   }
   if (row.disabled_at) {

--- a/backend/src/api/session.ts
+++ b/backend/src/api/session.ts
@@ -33,7 +33,7 @@ export function setSessionCookie(c: Context<AppEnv>, env: ApiEnv, sid: string): 
     sameSite: "Strict",
     path: "/",
     maxAge: env.SESSION_TTL_SECONDS,
-    secure: env.COOKIE_SECURE.toLowerCase() === "true"
+    secure: env.COOKIE_SECURE
   });
 }
 
@@ -41,7 +41,7 @@ export function clearSessionCookie(c: Context<AppEnv>, env: ApiEnv): void {
   deleteCookie(c, env.SESSION_COOKIE_NAME, {
     path: "/",
     sameSite: "Strict",
-    secure: env.COOKIE_SECURE.toLowerCase() === "true"
+    secure: env.COOKIE_SECURE
   });
 }
 

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -111,7 +111,6 @@ export const asset_styles = sqliteTable(
   },
   (t) => [
     uniqueIndex("asset_styles_user_asset_unique").on(t.user_id, t.asset),
-    index("idx_asset_style_user").on(t.user_id, t.asset),
   ]
 );
 

--- a/backend/src/migrate-from-mytools.ts
+++ b/backend/src/migrate-from-mytools.ts
@@ -44,6 +44,14 @@ function safeNum(value: unknown, fallback = 0): number {
   return Number.isFinite(n) ? n : fallback;
 }
 
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+function toIsoDateOrNull(v: unknown): string | null {
+  const s = String(v ?? "").slice(0, 10);
+  if (!ISO_DATE_RE.test(s)) return null;
+  const d = new Date(s);
+  return !isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s ? s : null;
+}
+
 // reason: legacy JSON shape from external source DB is unknown at compile time
 function readSourceJson(db: Database, name: string): any | null {
   const row = db.query(`SELECT data FROM files WHERE name = ? LIMIT 1`).get(name) as any; // reason: bun:sqlite raw query result has no type info
@@ -131,7 +139,11 @@ function main() {
 
     transactions.forEach((row: any, idx: number) => { // reason: legacy JSON shape, accessed via coercion
       const id = String(row.id ?? `tx-${idx}-${Date.now()}`);
-      const date = String(row.date ?? "").slice(0, 10);
+      const date = toIsoDateOrNull(row.date);
+      if (!date) {
+        console.warn(`[migrate] skipping transaction ${id}: invalid date "${row.date}"`);
+        return;
+      }
       const asset = String(row.asset ?? "");
       const tipo = String(row.tipo ?? row.type ?? "");
       const buyValue = safeNum(row.buyValue, 0);
@@ -144,7 +156,7 @@ function main() {
         .values({
           id,
           user_id: primary.id,
-          tx_date: date,
+          tx_date: date!,
           asset,
           tipo,
           derived_type: derivedType,
@@ -173,12 +185,17 @@ function main() {
 
     monthlySnapshots.forEach((row: any, idx: number) => { // reason: legacy JSON shape, accessed via coercion
       const id = String(row.id ?? `snap-${idx}-${Date.now()}`);
+      const snapshot_date = toIsoDateOrNull(row.date);
+      if (!snapshot_date) {
+        console.warn(`[migrate] skipping snapshot ${id}: invalid date "${row.date}"`);
+        return;
+      }
       targetDbo
         .insert(snapTbl)
         .values({
           id,
           user_id: primary.id,
-          snapshot_date: String(row.date ?? "").slice(0, 10),
+          snapshot_date,
           low_risk: safeNum(row.low, 0),
           medium_risk: safeNum(row.medium, 0),
           high_risk: safeNum(row.high, 0),

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -129,7 +129,7 @@ export type ApiEnv = {
   SESSION_COOKIE_NAME: string;
   ALLOWED_ORIGINS: string;
   PUBLIC_DIR: string;
-  COOKIE_SECURE: string;
+  COOKIE_SECURE: boolean;
   /** Max failed login attempts per IP per window. Disable rate limit with 0. */
   LOGIN_RATE_LIMIT_MAX: number;
   /** Sliding window length in seconds for the login rate limit. */

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -7,6 +7,8 @@ import { user_sessions } from "./db/schema.ts";
 import { createApi } from "./api/index.ts";
 import { applySecurityHeaders } from "./security-headers.ts";
 
+const ONE_YEAR_SECONDS = 365 * 24 * 60 * 60;
+
 const envSchema = z.object({
   HOST: z.string().default("0.0.0.0"),
   PORT: z.coerce.number().default(8001),
@@ -21,14 +23,14 @@ const envSchema = z.object({
   // box. Internet-facing deployments must serve over HTTPS and set
   // COOKIE_SECURE=true, otherwise the session cookie travels without the
   // Secure flag and can be intercepted.
-  COOKIE_SECURE: z.string().default("false"),
+  COOKIE_SECURE: z.preprocess((v) => String(v ?? "").toLowerCase() === "true", z.boolean()).default(false),
   LOGIN_RATE_LIMIT_MAX: z.coerce.number().default(5),
   LOGIN_RATE_LIMIT_WINDOW_SECONDS: z.coerce.number().default(15 * 60)
 });
 
 const env = envSchema.parse(process.env);
 
-if (env.COOKIE_SECURE.toLowerCase() !== "true") {
+if (!env.COOKIE_SECURE) {
   console.warn(
     "⚠️  COOKIE_SECURE is disabled: session cookies are sent without the Secure flag. Use HTTPS and set COOKIE_SECURE=true for internet-facing deployments."
   );
@@ -71,7 +73,7 @@ const server = Bun.serve({
       return api.fetch(req);
     }
 
-    const https = env.COOKIE_SECURE.toLowerCase() === "true";
+    const https = env.COOKIE_SECURE;
     if (req.method !== "GET" && req.method !== "HEAD") {
       const headers = new Headers({ "content-type": "application/json" });
       applySecurityHeaders(headers, https);
@@ -81,7 +83,6 @@ const server = Bun.serve({
       );
     }
 
-    const ONE_YEAR_SECONDS = 365 * 24 * 60 * 60;
     const staticFile = resolveStaticFile(env.PUBLIC_DIR, url.pathname);
     if (staticFile) {
       const headers = new Headers();

--- a/backend/src/test-helpers.ts
+++ b/backend/src/test-helpers.ts
@@ -13,7 +13,7 @@ export const TEST_ENV: ApiEnv = {
   SESSION_COOKIE_NAME: TEST_COOKIE_NAME,
   ALLOWED_ORIGINS: "http://localhost:5174,http://example.test",
   PUBLIC_DIR: "/tmp/nonexistent",
-  COOKIE_SECURE: "false",
+  COOKIE_SECURE: false,
   LOGIN_RATE_LIMIT_MAX: 5,
   LOGIN_RATE_LIMIT_WINDOW_SECONDS: 15 * 60
 };

--- a/backend/src/user-cli.ts
+++ b/backend/src/user-cli.ts
@@ -30,7 +30,10 @@ async function resolvePassword(): Promise<string> {
   if (fromEnv) return fromEnv;
 
   const fromArg = arg("password");
-  if (fromArg) return fromArg;
+  if (fromArg) {
+    console.warn("Warning: --password exposes the password in the process list. Prefer CLI_PASSWORD env or interactive mode.");
+    return fromArg;
+  }
 
   if (!process.stdin.isTTY) {
     throw new Error(
@@ -115,10 +118,11 @@ async function main() {
   if (cmd === "create") {
     const email = required("email").trim().toLowerCase();
     const password = await resolvePassword();
+    if (password.length > 1024) throw new Error("Password too long (max 1024 chars)");
     const name = arg("name") ?? null;
     const hash = await Bun.password.hash(password, { algorithm: "argon2id" });
     dbo.insert(users).values({ email, password_hash: hash, name }).run();
-    console.log(`User created: ${email}`);
+    console.log("User created successfully");
     db.close();
     return;
   }
@@ -126,6 +130,7 @@ async function main() {
   if (cmd === "reset-password") {
     const email = required("email").trim().toLowerCase();
     const password = await resolvePassword();
+    if (password.length > 1024) throw new Error("Password too long (max 1024 chars)");
     const hash = await Bun.password.hash(password, { algorithm: "argon2id" });
     const result = dbo
       .update(users)
@@ -134,7 +139,7 @@ async function main() {
       .returning({ id: users.id })
       .all();
     if (result.length === 0) throw new Error(`User not found: ${email}`);
-    console.log(`Password reset for ${email}`);
+    console.log("Password reset successfully");
     db.close();
     return;
   }
@@ -148,7 +153,7 @@ async function main() {
       .returning({ id: users.id })
       .all();
     if (result.length === 0) throw new Error(`User not found: ${email}`);
-    console.log(`Disabled user: ${email}`);
+    console.log("User disabled successfully");
     db.close();
     return;
   }
@@ -162,7 +167,7 @@ async function main() {
       .returning({ id: users.id })
       .all();
     if (result.length === 0) throw new Error(`User not found: ${email}`);
-    console.log(`Enabled user: ${email}`);
+    console.log("User enabled successfully");
     db.close();
     return;
   }

--- a/frontend/src/features/dashboard/AssetAllocationChart.tsx
+++ b/frontend/src/features/dashboard/AssetAllocationChart.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from "chart.js";
 import { Pie } from "react-chartjs-2";
 import type { AssetStats } from "../../lib/dashboard";
@@ -5,14 +6,7 @@ import type { AssetStats } from "../../lib/dashboard";
 ChartJS.register(ArcElement, Tooltip, Legend);
 
 export function AssetAllocationChart({ visibleAssets }: { visibleAssets: AssetStats[] }) {
-  if (visibleAssets.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground my-2" data-testid="allocation-chart-empty">
-        No allocation data.
-      </p>
-    );
-  }
-  const data = {
+  const data = useMemo(() => ({
     labels: visibleAssets.map((s) => s.asset),
     datasets: [
       {
@@ -21,7 +15,15 @@ export function AssetAllocationChart({ visibleAssets }: { visibleAssets: AssetSt
         backgroundColor: visibleAssets.map((s) => s.color)
       }
     ]
-  };
+  }), [visibleAssets]);
+
+  if (visibleAssets.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground my-2" data-testid="allocation-chart-empty">
+        No allocation data.
+      </p>
+    );
+  }
   return (
     <div className="max-w-[420px] mt-3.5" data-testid="allocation-chart">
       <Pie data={data} />

--- a/frontend/src/features/dashboard/AssetBlocks.tsx
+++ b/frontend/src/features/dashboard/AssetBlocks.tsx
@@ -8,8 +8,6 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
 
-const DEFAULT_ASSET_COLOR = DEFAULT_COLOR;
-
 type Props = {
   visibleAssets: AssetStats[];
   stylesMap: StylesMap | undefined;
@@ -111,7 +109,7 @@ export function AssetBlocks({ visibleAssets, stylesMap, onChangeStyle }: Props) 
 }
 
 function normalizeColor(input: string | null | undefined): string {
-  if (!input) return DEFAULT_ASSET_COLOR;
+  if (!input) return DEFAULT_COLOR;
   if (/^#[0-9a-fA-F]{6}$/.test(input)) return input;
-  return DEFAULT_ASSET_COLOR;
+  return DEFAULT_COLOR;
 }

--- a/frontend/src/features/dashboard/AssetPnlChart.tsx
+++ b/frontend/src/features/dashboard/AssetPnlChart.tsx
@@ -18,25 +18,21 @@ export function AssetPnlChart({ visibleAssets }: { visibleAssets: AssetStats[] }
   const colorPositive = useMemo(() => cssToken("--risk-low", "#34d399"), []);
   const colorNegative = useMemo(() => cssToken("--risk-high", "#fb7185"), []);
 
-  if (visibleAssets.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground my-2" data-testid="pnl-chart-empty">
-        No PnL data to chart.
-      </p>
-    );
-  }
-  const sorted = [...visibleAssets].sort((a, b) => b.pnl - a.pnl);
-  const data = {
-    labels: sorted.map((s) => s.asset),
-    datasets: [
-      {
-        label: "PnL",
-        data: sorted.map((s) => s.pnl),
-        backgroundColor: sorted.map((s) => (s.pnl >= 0 ? colorPositive : colorNegative))
-      }
-    ]
-  };
-  const options = {
+  const data = useMemo(() => {
+    const sorted = [...visibleAssets].sort((a, b) => b.pnl - a.pnl);
+    return {
+      labels: sorted.map((s) => s.asset),
+      datasets: [
+        {
+          label: "PnL",
+          data: sorted.map((s) => s.pnl),
+          backgroundColor: sorted.map((s) => (s.pnl >= 0 ? colorPositive : colorNegative))
+        }
+      ]
+    };
+  }, [visibleAssets, colorPositive, colorNegative]);
+
+  const options = useMemo(() => ({
     plugins: { legend: { display: false } },
     scales: {
       y: {
@@ -45,7 +41,15 @@ export function AssetPnlChart({ visibleAssets }: { visibleAssets: AssetStats[] }
         }
       }
     }
-  };
+  }), []);
+
+  if (visibleAssets.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground my-2" data-testid="pnl-chart-empty">
+        No PnL data to chart.
+      </p>
+    );
+  }
   return (
     <div className="max-w-[420px] mt-3.5" data-testid="pnl-chart">
       <Bar data={data} options={options} />

--- a/frontend/src/features/settings/useBackupActions.ts
+++ b/frontend/src/features/settings/useBackupActions.ts
@@ -1,6 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { z } from "zod";
-import { apiEnvelopeSchema, apiFetch, okSchema } from "@/lib";
+import { apiEnvelopeSchema, apiFetch, okSchema, todayIso } from "@/lib";
 
 function downloadBlob(blob: Blob, filename: string) {
   const a = document.createElement("a");
@@ -9,15 +9,10 @@ function downloadBlob(blob: Blob, filename: string) {
   a.download = filename;
   a.click();
   // Revoke after click is dispatched so the browser has time to start the download.
-  setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+  queueMicrotask(() => URL.revokeObjectURL(objectUrl));
 }
 
-function dateStamp(): string {
-  return new Date().toISOString().slice(0, 10);
-}
-
-// reason: backup payload is arbitrary JSON passed straight to JSON.stringify; shape is validated server-side
-const anySchema = apiEnvelopeSchema(z.any());
+const anySchema = apiEnvelopeSchema(z.any()); // reason: backup payload is arbitrary JSON passed to JSON.stringify; shape validated server-side
 
 export function useBackupActions() {
   const queryClient = useQueryClient();
@@ -26,7 +21,7 @@ export function useBackupActions() {
     const payload = await apiFetch("/api/v1/backup/json", { method: "GET" }, (raw) => anySchema.parse(raw).data);
     downloadBlob(
       new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" }),
-      `money-backup-${dateStamp()}.json`
+      `money-backup-${todayIso()}.json`
     );
   };
 
@@ -48,14 +43,19 @@ export function useBackupActions() {
   const exportXlsx = async () => {
     const res = await fetch("/api/v1/backup/xlsx", { credentials: "include" });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    downloadBlob(await res.blob(), `money-export-${dateStamp()}.xlsx`);
+    downloadBlob(await res.blob(), `money-export-${todayIso()}.xlsx`);
   };
 
   const importXlsx = async (file: File) => {
     const form = new FormData();
     form.set("file", file);
     const res = await fetch("/api/v1/backup/xlsx/import", { method: "POST", credentials: "include", body: form });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      let msg = `HTTP ${res.status}`;
+      try { msg = JSON.parse(text)?.error?.message || msg; } catch { /* ignore */ }
+      throw new Error(msg);
+    }
     await queryClient.invalidateQueries();
   };
 

--- a/frontend/src/features/snapshots/MonthlyRiskChart.tsx
+++ b/frontend/src/features/snapshots/MonthlyRiskChart.tsx
@@ -20,24 +20,20 @@ export function MonthlyRiskChart({ snapshots }: { snapshots: Snapshot[] }) {
   const colorHigh = useMemo(() => cssToken("--risk-high", "#fb7185"), []);
   const colorLiquid = useMemo(() => cssToken("--risk-liquid", "#60a5fa"), []);
 
-  if (snapshots.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground my-2" data-testid="snapshot-chart-empty">
-        No snapshots to chart.
-      </p>
-    );
-  }
-  const asc = [...snapshots].reverse();
-  const data = {
-    labels: asc.map((s) => s.snapshotDate),
-    datasets: [
-      { label: "Low", data: asc.map((s) => s.lowRisk), backgroundColor: colorLow },
-      { label: "Medium", data: asc.map((s) => s.mediumRisk), backgroundColor: colorMedium },
-      { label: "High", data: asc.map((s) => s.highRisk), backgroundColor: colorHigh },
-      { label: "Liquid", data: asc.map((s) => s.liquid), backgroundColor: colorLiquid }
-    ]
-  };
-  const options = {
+  const data = useMemo(() => {
+    const asc = [...snapshots].reverse();
+    return {
+      labels: asc.map((s) => s.snapshotDate),
+      datasets: [
+        { label: "Low", data: asc.map((s) => s.lowRisk), backgroundColor: colorLow },
+        { label: "Medium", data: asc.map((s) => s.mediumRisk), backgroundColor: colorMedium },
+        { label: "High", data: asc.map((s) => s.highRisk), backgroundColor: colorHigh },
+        { label: "Liquid", data: asc.map((s) => s.liquid), backgroundColor: colorLiquid }
+      ]
+    };
+  }, [snapshots, colorLow, colorMedium, colorHigh, colorLiquid]);
+
+  const options = useMemo(() => ({
     plugins: { legend: { position: "bottom" as const } },
     scales: {
       x: { stacked: true },
@@ -48,7 +44,15 @@ export function MonthlyRiskChart({ snapshots }: { snapshots: Snapshot[] }) {
         }
       }
     }
-  };
+  }), []);
+
+  if (snapshots.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground my-2" data-testid="snapshot-chart-empty">
+        No snapshots to chart.
+      </p>
+    );
+  }
   return (
     <div className="max-w-[420px] mt-3.5" data-testid="snapshot-chart">
       <Bar data={data} options={options} />

--- a/frontend/src/features/snapshots/SnapshotsPanel.tsx
+++ b/frontend/src/features/snapshots/SnapshotsPanel.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
-import { apiFetch } from "@/lib";
+import { apiFetch, todayIso } from "@/lib";
 import { stylesResponse, txListResponse } from "@/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { MonthlyRiskChart } from "./MonthlyRiskChart";
@@ -11,10 +11,9 @@ import { useSnapMutation } from "./useSnapMutation";
 import { useDeleteSnapshot } from "./useDeleteSnapshot";
 import { type SnapFormDefaults } from "./schemas";
 
-const snapDefaults: SnapFormDefaults = {
-  snapshotDate: new Date().toISOString().slice(0, 10),
-  liquid: ""
-};
+function getSnapDefaults(): SnapFormDefaults {
+  return { snapshotDate: todayIso(), liquid: "" };
+}
 
 export function SnapshotsPanel() {
   const snapQuery = useSnapshotsQuery(true);
@@ -35,11 +34,11 @@ export function SnapshotsPanel() {
   });
 
   const form = useForm<SnapFormDefaults>({
-    defaultValues: { ...snapDefaults }
+    defaultValues: getSnapDefaults()
   });
 
   const snapMutation = useSnapMutation(() => {
-    form.reset({ snapshotDate: new Date().toISOString().slice(0, 10), liquid: "" });
+    form.reset(getSnapDefaults());
   });
   const deleteMutation = useDeleteSnapshot();
 

--- a/frontend/src/features/transactions/schemas.ts
+++ b/frontend/src/features/transactions/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { todayIso } from "@/lib";
 
 export const TIPO_OPTIONS = [
   "nuovo vincolo",
@@ -37,7 +38,7 @@ export type TxFormDefaults = Omit<TxFormValues, "buyValue" | "pnl"> & {
 };
 
 export const txFormDefaults: TxFormDefaults = {
-  txDate: new Date().toISOString().slice(0, 10),
+  txDate: todayIso(),
   asset: "",
   tipo: "nuovo vincolo",
   buyValue: "",

--- a/frontend/src/lib.ts
+++ b/frontend/src/lib.ts
@@ -33,6 +33,10 @@ export function formatCurrency(value: number) {
 
 const SHORT_DATE = new Intl.DateTimeFormat("it-IT", { year: "numeric", month: "2-digit", day: "2-digit" });
 
+export function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
 export function formatShortDate(iso: string | null | undefined): string {
   if (!iso) return "—";
   const ms = Date.parse(iso);

--- a/frontend/src/lib/dashboard.test.ts
+++ b/frontend/src/lib/dashboard.test.ts
@@ -87,8 +87,9 @@ describe("findLastTxDate", () => {
     expect(findLastTxDate([])).toBeNull();
   });
 
-  test("returns max ISO date string", () => {
-    expect(findLastTxDate([tx("A", 1, 0, "2026-01-01"), tx("B", 1, 0, "2026-05-17")])).toBe(
+  test("returns first element date (assumes DESC order from API)", () => {
+    // API returns transactions ORDER BY tx_date DESC, so first element = latest
+    expect(findLastTxDate([tx("B", 1, 0, "2026-05-17"), tx("A", 1, 0, "2026-01-01")])).toBe(
       "2026-05-17"
     );
   });

--- a/frontend/src/lib/dashboard.ts
+++ b/frontend/src/lib/dashboard.ts
@@ -76,7 +76,7 @@ export function cycleRisk(current: RiskLevel | null): RiskLevel {
   return RISK_LEVELS[(idx + 1) % RISK_LEVELS.length]!;
 }
 
+/** Assumes transactions are sorted DESC by txDate (as returned by the API). */
 export function findLastTxDate(transactions: readonly Transaction[]): string | null {
-  // API returns transactions ORDER BY tx_date DESC, so first element has the latest date
   return transactions[0]?.txDate ?? null;
 }

--- a/frontend/src/lib/dashboard.ts
+++ b/frontend/src/lib/dashboard.ts
@@ -77,11 +77,6 @@ export function cycleRisk(current: RiskLevel | null): RiskLevel {
 }
 
 export function findLastTxDate(transactions: readonly Transaction[]): string | null {
-  if (transactions.length === 0) return null;
-  let latest: string | null = null;
-  for (const row of transactions) {
-    if (!row.txDate) continue;
-    if (!latest || row.txDate > latest) latest = row.txDate;
-  }
-  return latest;
+  // API returns transactions ORDER BY tx_date DESC, so first element has the latest date
+  return transactions[0]?.txDate ?? null;
 }


### PR DESCRIPTION
## Summary

**Security**
- Bump `hono` backend 4.12.23 → 4.12.26: fixes 5 CVEs (CORS credential leak, cookie-merging, path traversal, body-limit bypass, header drop)
- Add base64 length guard before `Buffer.from` in xlsx import (pre-allocation DoS)
- Add OOXML magic-byte check (`PK\x03\x04`) before ExcelJS parse + guard for < 4 byte uploads
- Cap xlsx import at 50 000 rows per sheet (parity with json import zod schema)
- Parse `COOKIE_SECURE` once as `boolean` in `envSchema` via `z.preprocess`, replacing 5 string comparisons across server/middleware/session
- CLI: warn when `--password` arg is used (process-list PII exposure)
- CLI: add 1024-char password cap before argon2id hash call
- CLI: remove email from `console.log` success messages (PII §10)

**Bugs**
- Fix `showZeroAssets` `Boolean("false") === true` in json import; use explicit string comparison matching the xlsx import logic
- Add `toIsoDateOrNull` date validation in `migrate-from-mytools`; skip rows with invalid dates + warn
- Wrap login session-wipe + session-create in `db.transaction()` — crash between the two no longer locks the user out
- Wrap expired-session DELETE in try/catch in `sessionGuard` — SQLite BUSY no longer returns 500
- Surface server error message in `importXlsx` (was always "HTTP N")

**Quality**
- Drop redundant `idx_asset_style_user` index (same columns as unique index) via Drizzle migration `0001_drop_redundant_index`
- Move `ONE_YEAR_SECONDS` to module scope in `server.ts`
- Remove dead `DEFAULT_ASSET_COLOR` alias in `AssetBlocks` (was re-export of `DEFAULT_COLOR` with no semantic difference)
- Extract `todayIso()` utility in `frontend/src/lib.ts`; replaces 4 inline `new Date().toISOString().slice(0,10)` call sites
- Make `SnapshotsPanel` form defaults a function (`getSnapDefaults`) — reset uses today's date, not mount-time date
- `useBackupActions`: replace `setTimeout(revokeObjectURL, 0)` with `queueMicrotask` (AGENTS.md §13 compliance)
- Use `db.transaction()` return value in login handler — removes mutable `let newSid` + non-null assert

**Performance**
- Wrap chart data objects in `useMemo` in `AssetAllocationChart`, `AssetPnlChart`, `MonthlyRiskChart` — avoids Chart.js re-animation on unrelated parent re-renders; hooks placed before early returns (Rules of Hooks)
- `findLastTxDate`: replace O(n) max-loop with O(1) first-element access; API returns `ORDER BY tx_date DESC`; test updated to document this contract

## Deferred findings

Nuovi deferred findings: https://github.com/LiukScot/money/issues/108

## Sub-analyst reports

- **Security:** hono 5 CVEs (HIGH); base64 pre-allocation DoS (MEDIUM); X-Forwarded-For rate-limit bypass (MEDIUM, deferred); CSP unsafe-inline (LOW, deferred)
- **Quality:** COOKIE_SECURE string→bool (HIGH); redundant index (MEDIUM); dead alias + magic-number duplication (MEDIUM/LOW)
- **Bugs:** showZeroAssets bool coercion bug (MEDIUM); login session race (LOW); expired session 500 (LOW); xlsx error surfacing (MEDIUM)
- **Tests:** expired-session cleanup test (HIGH); xlsx import coverage (HIGH); rate-limit /change-password (MEDIUM); IDOR snapshots PUT (MEDIUM) — all deferred
- **Deps:** hono CVE bump (HIGH); @types/node major 25→26 not bumped (MEDIUM, Dependabot will open PR)
- **Performance:** useMemo charts (MEDIUM); findLastTxDate O(1) (LOW); unbounded backup SELECT (LOW, deferred)

---
Generated automatically by Codebase Analyst — 2026-06-20