### PR TITLE
fix: address deferred codebase-analyst findings 2026-06-20

### DIFF
--- a/backend/src/api/auth.ts
+++ b/backend/src/api/auth.ts
@@ -42,10 +42,6 @@ function clientIp(c: Context<AppEnv>): string {
 
 export const authRoutes = new Hono<AppEnv>();
 
-authRoutes.post("/register", (c) =>
-  jsonError(c, "SIGNUP_DISABLED", "Signup is disabled", 403)
-);
-
 authRoutes.post("/login", async (c, next) => {
   const decision = c.get("loginRateLimiter").check(clientIp(c));
   if (!decision.allowed) {

--- a/backend/src/api/backup-helpers.ts
+++ b/backend/src/api/backup-helpers.ts
@@ -147,7 +147,9 @@ export function applyImport(db: SQLiteDB, userId: number, payload: ImportPayload
     })
     .filter((r): r is NonNullable<typeof r> => r !== null);
   if (txRows.length > 0) {
-    dbo.insert(transactions).values(txRows).onConflictDoNothing().run();
+    const r = dbo.insert(transactions).values(txRows).onConflictDoNothing().run();
+    const skipped = txRows.length - Number(r.changes);
+    if (skipped > 0) console.warn(`[import] ${skipped} transaction row(s) skipped (duplicate id)`);
   }
 
   const validDirections = new Set(["income", "expense"]);
@@ -167,7 +169,9 @@ export function applyImport(db: SQLiteDB, userId: number, payload: ImportPayload
     })
     .filter((r): r is NonNullable<typeof r> => r !== null);
   if (mmRows.length > 0) {
-    dbo.insert(monthly_movements).values(mmRows).onConflictDoNothing().run();
+    const r = dbo.insert(monthly_movements).values(mmRows).onConflictDoNothing().run();
+    const skipped = mmRows.length - Number(r.changes);
+    if (skipped > 0) console.warn(`[import] ${skipped} monthly-movement row(s) skipped (duplicate id)`);
   }
 
   const snapRows = payload.monthlySnapshots
@@ -186,7 +190,9 @@ export function applyImport(db: SQLiteDB, userId: number, payload: ImportPayload
     })
     .filter((r): r is NonNullable<typeof r> => r !== null);
   if (snapRows.length > 0) {
-    dbo.insert(monthly_snapshots).values(snapRows).onConflictDoNothing().run();
+    const r = dbo.insert(monthly_snapshots).values(snapRows).onConflictDoNothing().run();
+    const skipped = snapRows.length - Number(r.changes);
+    if (skipped > 0) console.warn(`[import] ${skipped} monthly-snapshot row(s) skipped (duplicate id)`);
   }
 
   if (payload.replaceStyles) {

--- a/backend/src/api/backup.ts
+++ b/backend/src/api/backup.ts
@@ -278,19 +278,3 @@ backupRoutes.post("/xlsx/import", async (c) => {
   });
 });
 
-export const purgeRoutes = new Hono<AppEnv>();
-
-purgeRoutes.post("/purge", (c) => {
-  const db = c.get("db");
-  const user = c.get("user");
-  const tx = db.transaction(() => {
-    wipeUserData(db, user.id, true, true);
-  });
-  try {
-    tx();
-  } catch (e) {
-    console.error("[purge] failed:", e);
-    return jsonError(c, "PURGE_FAILED", "Purge failed. Check server logs for details.", 500);
-  }
-  return jsonData(c, { ok: true });
-});

--- a/backend/src/api/index.ts
+++ b/backend/src/api/index.ts
@@ -3,7 +3,8 @@ import type { SQLiteDB } from "../db.ts";
 import type { ApiEnv } from "../schemas.ts";
 import { createRateLimiter } from "../rate-limit.ts";
 import { authRoutes } from "./auth.ts";
-import { backupRoutes, purgeRoutes } from "./backup.ts";
+import { backupRoutes } from "./backup.ts";
+import { purgeRoutes } from "./purge.ts";
 import { movementRoutes } from "./movements.ts";
 import { originGuard, securityHeaders, sessionGuard } from "./middleware.ts";
 import { prefsRoutes } from "./prefs.ts";
@@ -21,8 +22,7 @@ export type CreateApiOptions = {
 const PUBLIC_AUTH_PATHS = new Set([
   "/api/v1/auth/login",
   "/api/v1/auth/logout",
-  "/api/v1/auth/session",
-  "/api/v1/auth/register"
+  "/api/v1/auth/session"
 ]);
 
 export function createApi(opts: CreateApiOptions) {

--- a/backend/src/api/purge.ts
+++ b/backend/src/api/purge.ts
@@ -1,0 +1,22 @@
+import { Hono } from "hono";
+
+import { wipeUserData } from "./backup-helpers.ts";
+import type { AppEnv } from "./types.ts";
+import { jsonData, jsonError } from "./responses.ts";
+
+export const purgeRoutes = new Hono<AppEnv>();
+
+purgeRoutes.post("/purge", (c) => {
+  const db = c.get("db");
+  const user = c.get("user");
+  const tx = db.transaction(() => {
+    wipeUserData(db, user.id, true, true);
+  });
+  try {
+    tx();
+  } catch (e) {
+    console.error("[purge] failed:", e);
+    return jsonError(c, "PURGE_FAILED", "Purge failed. Check server logs for details.", 500);
+  }
+  return jsonData(c, { ok: true });
+});

--- a/backend/src/api/transactions.ts
+++ b/backend/src/api/transactions.ts
@@ -9,6 +9,14 @@ import type { AppEnv } from "./types.ts";
 import { jsonData, jsonError, validateJson } from "./responses.ts";
 import { readPageBounds } from "./pagination.ts";
 
+function deriveFields(body: ReturnType<typeof txSchema.parse>) {
+  const derivedType = body.derivedType || inferType(body.tipo, body.buyValue, body.pnl);
+  const currentValue = Number.isFinite(body.currentValue)
+    ? Number(body.currentValue)
+    : body.buyValue + body.pnl;
+  return { derivedType, currentValue };
+}
+
 export const transactionRoutes = new Hono<AppEnv>();
 
 transactionRoutes.get("/", (c) => {
@@ -31,10 +39,7 @@ transactionRoutes.post("/", validateJson(txSchema), (c) => {
   const db = c.get("db");
   const user = c.get("user");
   const id = makeId("tx");
-  const derivedType = body.derivedType || inferType(body.tipo, body.buyValue, body.pnl);
-  const currentValue = Number.isFinite(body.currentValue)
-    ? Number(body.currentValue)
-    : body.buyValue + body.pnl;
+  const { derivedType, currentValue } = deriveFields(body);
   getDrizzle(db)
     .insert(transactions)
     .values({
@@ -58,10 +63,7 @@ transactionRoutes.put("/:id", validateJson(txSchema), (c) => {
   const body = c.req.valid("json");
   const db = c.get("db");
   const user = c.get("user");
-  const derivedType = body.derivedType || inferType(body.tipo, body.buyValue, body.pnl);
-  const currentValue = Number.isFinite(body.currentValue)
-    ? Number(body.currentValue)
-    : body.buyValue + body.pnl;
+  const { derivedType, currentValue } = deriveFields(body);
   const result = getDrizzle(db)
     .update(transactions)
     .set({

--- a/backend/src/auth.test.ts
+++ b/backend/src/auth.test.ts
@@ -5,6 +5,7 @@ import {
   extractSessionCookie,
   loginRequest,
   seedUser,
+  setupAuthed,
   TEST_COOKIE_NAME
 } from "./test-helpers.ts";
 
@@ -101,19 +102,6 @@ describe("POST /api/v1/auth/login", () => {
     const ctx = createTestApi();
     const res = await apiRequest(ctx.api, "/api/v1/auth/login", { method: "POST", body: {} });
     expect(res.status).toBe(400);
-  });
-});
-
-describe("POST /api/v1/auth/register", () => {
-  test("returns 403 SIGNUP_DISABLED", async () => {
-    const ctx = createTestApi();
-    const res = await apiRequest(ctx.api, "/api/v1/auth/register", {
-      method: "POST",
-      body: { email: "new@example.com", password: "Password123!" }
-    });
-    expect(res.status).toBe(403);
-    const body = await res.json();
-    expect(body.error.code).toBe("SIGNUP_DISABLED");
   });
 });
 
@@ -236,6 +224,34 @@ describe("POST /api/v1/auth/change-password", () => {
       body: { email: seeded.email, password: "NewPassword456!" }
     });
     expect(loginRes.status).toBe(200);
+  });
+});
+
+describe("session expiry", () => {
+  test("expired session on protected route returns 401 and deletes the row", async () => {
+    const { ctx, user } = await setupAuthed();
+    ctx.db
+      .query(`INSERT INTO user_sessions (sid, user_id, email, expires_at) VALUES (?,?,?,?)`)
+      .run("expiredsid", user.id, user.email, 1);
+    const res = await apiRequest(ctx.api, "/api/v1/transactions", {
+      cookie: `${TEST_COOKIE_NAME}=expiredsid`
+    });
+    expect(res.status).toBe(401);
+    const row = ctx.db.query(`SELECT * FROM user_sessions WHERE sid=?`).get("expiredsid");
+    expect(row).toBeNull();
+  });
+});
+
+describe("disabled user post-login", () => {
+  test("GET /session returns authenticated=false after user is disabled", async () => {
+    const { ctx, user, cookie } = await setupAuthed();
+    ctx.db
+      .query(`UPDATE users SET disabled_at=? WHERE id=?`)
+      .run(new Date().toISOString(), user.id);
+    const res = await apiRequest(ctx.api, "/api/v1/auth/session", { cookie });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.authenticated).toBe(false);
   });
 });
 

--- a/backend/src/backup.test.ts
+++ b/backend/src/backup.test.ts
@@ -174,6 +174,54 @@ describe("/api/v1/backup/xlsx/import", () => {
   });
 });
 
+describe("/api/v1/backup/xlsx/import — input validation", () => {
+  test("rejects base64 string exceeding size limit (FILE_TOO_LARGE)", async () => {
+    const { ctx, cookie } = await setupAuthed();
+    // 10 MB * 4/3 + 5 bytes exceeds the base64 ceiling.
+    const oversized = "A".repeat(Math.ceil(10 * 1024 * 1024 * 4 / 3) + 5);
+    const res = await apiRequest(ctx.api, "/api/v1/backup/xlsx/import", {
+      method: "POST",
+      cookie,
+      body: { base64: oversized }
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("FILE_TOO_LARGE");
+  });
+
+  test("rejects base64 of non-XLSX bytes (INVALID_FILE)", async () => {
+    const { ctx, cookie } = await setupAuthed();
+    const garbage = Buffer.from("not an xlsx file").toString("base64");
+    const res = await apiRequest(ctx.api, "/api/v1/backup/xlsx/import", {
+      method: "POST",
+      cookie,
+      body: { base64: garbage }
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("INVALID_FILE");
+  });
+
+  test("rejects multipart file shorter than 4 bytes (INVALID_FILE)", async () => {
+    const { ctx, cookie } = await setupAuthed();
+    const tinyFile = new File([new Uint8Array([0x50, 0x4b])], "test.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    const form = new FormData();
+    form.append("file", tinyFile);
+    const res = await ctx.api.fetch(
+      new Request("http://test/api/v1/backup/xlsx/import", {
+        method: "POST",
+        headers: { cookie },
+        body: form
+      })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("INVALID_FILE");
+  });
+});
+
 describe("/api/v1/data/purge", () => {
   test("POST requires auth", async () => {
     const { ctx } = await setupAuthed();

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -46,8 +46,7 @@ function baselineIfNeeded(db: SQLiteDB): void {
     .get();
   if (!usersExists || drizzleMetaExists) return;
   const migrations = readMigrationFiles({ migrationsFolder: MIGRATIONS_FOLDER });
-  const first = migrations[0];
-  if (!first) return;
+  if (migrations.length === 0) return;
   const tx = db.transaction(() => {
     db.exec(
       `CREATE TABLE IF NOT EXISTS __drizzle_migrations (
@@ -56,10 +55,10 @@ function baselineIfNeeded(db: SQLiteDB): void {
         created_at NUMERIC
       )`
     );
-    db.run(`INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)`, [
-      first.hash,
-      Date.now()
-    ]);
+    const now = Date.now();
+    for (const m of migrations) {
+      db.run(`INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)`, [m.hash, now]);
+    }
   });
   tx();
 }

--- a/backend/src/monthly-snapshots.test.ts
+++ b/backend/src/monthly-snapshots.test.ts
@@ -120,6 +120,24 @@ describe("PUT/DELETE /api/v1/monthly-snapshots/:id", () => {
     expect(res.status).toBe(200);
   });
 
+  test("PUT returns 404 when other user tries to update (IDOR)", async () => {
+    const { ctx, cookie } = await setupAuthed();
+    const created = await apiRequest(ctx.api, "/api/v1/monthly-snapshots", {
+      method: "POST",
+      cookie,
+      body: validSnap
+    });
+    const { data } = await created.json();
+    await seedUser(ctx.db, { email: "other@example.com", password: "Password123!" });
+    const otherCookie = await loginRequest(ctx.api, "other@example.com", "Password123!");
+    const res = await apiRequest(ctx.api, `/api/v1/monthly-snapshots/${data.id}`, {
+      method: "PUT",
+      cookie: otherCookie,
+      body: validSnap
+    });
+    expect(res.status).toBe(404);
+  });
+
   test("PUT returns 404 for unknown id", async () => {
     const { ctx, cookie } = await setupAuthed();
     const res = await apiRequest(ctx.api, "/api/v1/monthly-snapshots/ghost", {

--- a/backend/src/rate-limit.test.ts
+++ b/backend/src/rate-limit.test.ts
@@ -73,6 +73,47 @@ describe("POST /api/v1/auth/login rate limit (integration)", () => {
     expect(body.error.code).toBe("RATE_LIMITED");
   });
 
+  test("same rate-limit bucket applies to /change-password", async () => {
+    const ctx = createTestApi();
+    const seeded = await seedUser(ctx.db, { email: "rl2@example.com", password: "Password123!" });
+    // Login first to get a valid session (change-password requires auth via global sessionGuard).
+    const loginRes = await ctx.api.fetch(
+      new Request("http://test/api/v1/auth/login", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-forwarded-for": "10.0.0.99" },
+        body: JSON.stringify({ email: seeded.email, password: seeded.password })
+      })
+    );
+    const sessionCookie = loginRes.headers.get("set-cookie")?.split(";")[0] ?? "";
+
+    // Exhaust the bucket via 5 more login attempts (loginRateLimiter is shared).
+    for (let i = 0; i < 5; i += 1) {
+      await ctx.api.fetch(
+        new Request("http://test/api/v1/auth/login", {
+          method: "POST",
+          headers: { "content-type": "application/json", "x-forwarded-for": "10.0.0.99" },
+          body: JSON.stringify({ email: seeded.email, password: "Wrong!" })
+        })
+      );
+    }
+
+    // change-password from same IP with valid session → rate-limited before inner handler runs.
+    const res = await ctx.api.fetch(
+      new Request("http://test/api/v1/auth/change-password", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-forwarded-for": "10.0.0.99",
+          cookie: sessionCookie
+        },
+        body: JSON.stringify({ currentPassword: "Wrong!", newPassword: "NewPassword456!" })
+      })
+    );
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("RATE_LIMITED");
+  });
+
   test("different IPs each get their own bucket", async () => {
     const ctx = createTestApi();
     await seedUser(ctx.db, { email: "buckets@example.com", password: "Password123!" });

--- a/frontend/src/features/snapshots/SnapshotsPanel.tsx
+++ b/frontend/src/features/snapshots/SnapshotsPanel.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { apiFetch, todayIso } from "@/lib";
-import { stylesResponse, txListResponse } from "@/types";
+import { stylesResponse } from "@/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { MonthlyRiskChart } from "./MonthlyRiskChart";
 import { SnapshotForm } from "./SnapshotForm";
@@ -10,6 +10,7 @@ import { useSnapshotsQuery } from "./useSnapshotsQuery";
 import { useSnapMutation } from "./useSnapMutation";
 import { useDeleteSnapshot } from "./useDeleteSnapshot";
 import { type SnapFormDefaults } from "./schemas";
+import { useTransactionsQuery } from "../transactions/useTransactionsQuery";
 
 function getSnapDefaults(): SnapFormDefaults {
   return { snapshotDate: todayIso(), liquid: "" };
@@ -20,13 +21,7 @@ export function SnapshotsPanel() {
 
   // Keep tx + styles caches warm so useSnapMutation can derive risk totals
   // and so the Add button only enables once both are ready.
-  const txQuery = useQuery({
-    queryKey: ["transactions"],
-    queryFn: async ({ signal }) =>
-      apiFetch("/api/v1/transactions", { method: "GET", signal }, (raw) =>
-        txListResponse.parse(raw).data
-      )
-  });
+  const txQuery = useTransactionsQuery(true);
   const stylesQuery = useQuery({
     queryKey: ["styles"],
     queryFn: async ({ signal }) =>


### PR DESCRIPTION
## Summary

- Remove dead /register stub route (signup permanently off)
- Extract deriveFields() helper in transactions.ts (DRY POST/PUT)
- Log warning when backup import drops duplicate IDs silently
- Fix baselineIfNeeded to mark all migrations as applied for pre-Drizzle DBs
- Move purgeRoutes to dedicated api/purge.ts
- SnapshotsPanel: reuse useTransactionsQuery instead of inline duplicate
- Tests: expired session, disabled-user session, change-password rate-limit, PUT IDOR, xlsx input validation

Closes #108

Co-Authored-By: claude-sonnet-4-6